### PR TITLE
Show concepts by default

### DIFF
--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -66,7 +66,7 @@ const children = ref<ListItem[]>([]);
 const concepts = ref<Concept[]>([]); // only for vocab
 const properties = ref<AnnotatedQuad[]>([]);
 const blankNodes = ref<AnnotatedQuad[]>([]);
-const hideConcepts = ref(true); // only for vocab
+const hideConcepts = ref(false); // only for vocab
 const collapseAll = ref(true); // only for vocab
 
 const isAltView = ref(false);


### PR DESCRIPTION
In almost all cases, when a user clicks on a concept scheme, they most likely want to view the concepts. 

This is also the original behaviour from Prez v2 and the only behaviour for SKOS Collections.