### PR TITLE
Set base from env in vite.config.ts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM node:alpine AS build
+ARG VITE_BASE_URL="/"
+ENV VITE_BASE_URL "${VITE_BASE_URL}"
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,5 +36,5 @@ export default defineConfig({
             }
         }
     },
-    base: process.env.GH_PAGES_DEMO ? "/prez-ui/" : "/",
+    base: process.env.GH_PAGES_DEMO ? "/prez-ui/" : (process.env.VITE_BASE_URL || '/'),
 });


### PR DESCRIPTION
Configure Vite base URL from VITE_BASE_URL env variable (incl. Docker).