### PR TITLE
Update map search query to reflect updated prez BE

### DIFF
--- a/src/stores/datasetsStore.ts
+++ b/src/stores/datasetsStore.ts
@@ -27,8 +27,8 @@ CONSTRUCT {?ds a <${config.spatial.datasetClass}> ;
     <${config.spatial.membershipRelationship}> ?fc .
   ?fc a geo:FeatureCollection ;
   <${config.props.fcLabel}> ?fc_title}
-WHERE {<https://prez.dev/DatasetList> <${config.spatial.membershipRelationship}> ?ds.
-  ?ds <${config.spatial.membershipRelationship}> ?fc ;
+WHERE { ?ds a <${config.spatial.datasetClass}> ;
+      <${config.spatial.membershipRelationship}> ?fc ;
       <${config.props.dsLabel}> ?ds_title .
   ?fc <${config.props.fcLabel}> ?fc_title
       }`


### PR DESCRIPTION
prez BE no longer creates an instances of datasetlist to list datasets off. This update changes the map search SPARQL query to look for datasets based on their class 