### PR TITLE
Streamline subsystem naming and content

### DIFF
--- a/src/components/FlavourHome.vue
+++ b/src/components/FlavourHome.vue
@@ -38,9 +38,9 @@ const homeLinks = computed(() => {
 
 onMounted(() => {
     ui.rightNavConfig = { enabled: false };
-    document.title = `${props.flavour} | Prez`;
+    document.title = `${getPrezSystemLabel(props.flavour) + " Home"} | Prez`;
     ui.pageHeading = { name: props.flavour, url: `/${letter.value}`};
-    ui.breadcrumbs = [{ name: props.flavour, url: `/${letter.value}` }];
+    ui.breadcrumbs = [{ name: getPrezSystemLabel(props.flavour) + " Home", url: `/${letter.value}` }];
 });
 </script>
 

--- a/src/components/FlavourHome.vue
+++ b/src/components/FlavourHome.vue
@@ -4,6 +4,7 @@ import { RouterLink } from "vue-router";
 import { useUiStore } from "@/stores/ui";
 import type { PrezFlavour } from "@/types";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const ui = useUiStore();
 
@@ -44,7 +45,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <h1 class="page-title">{{ props.flavour }}</h1>
+    <h1 class="page-title">{{ getPrezSystemLabel(props.flavour) }}</h1>
     <div class="home-page-links">
         <RouterLink v-for="link in homeLinks" :to="link.url" class="home-page-link">
             <h4 class="link-title">{{ link.label }}</h4>

--- a/src/components/navs/MainNav.vue
+++ b/src/components/navs/MainNav.vue
@@ -111,7 +111,7 @@ const props = defineProps<{
             <div class="nav-item"><RouterLink to="/sparql" class="nav-link">SPARQL</RouterLink></div>
             <div class="nav-item"><RouterLink to="/profiles" :class="`nav-link ${route.path.startsWith('/profiles') ? 'active' : ''}`">Profiles</RouterLink></div>
             <div class="nav-item"><RouterLink to="/about" class="nav-link">About</RouterLink></div>
-            <div class="nav-item"><RouterLink to="/docs" class="nav-link">API Docs</RouterLink></div>
+            <div class="nav-item"><RouterLink to="/docs" class="nav-link">API Documentation</RouterLink></div>
             <div class="bottom-nav-items">
                 <a href="https://github.com/RDFLib/prez-ui" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> Prez UI v{{ props.version }}</a>
                 <a href="https://github.com/RDFLib/prez" target="_blank" rel="noopener noreferrer"><i class="fa-brands fa-github"></i> Prez API v{{ ui.apiVersion }}</a>

--- a/src/components/navs/MainNav.vue
+++ b/src/components/navs/MainNav.vue
@@ -7,7 +7,7 @@ import { enabledPrezsConfigKey, type PrezFlavour } from "@/types";
 const routes: {[key: string]: any[]} = {
     "VocPrez": [
         {
-            "label": "Vocabs",
+            "label": "Vocabularies",
             "to": "/v/vocab"
         },
         {
@@ -72,6 +72,20 @@ const activePrez = computed(() => {
 const collapse = ref(false);
 const dropdowns = ref(enabledPrezs.value.reduce<{[key: string]: boolean}>((obj, prez) => (obj[prez] = prez === activePrez.value, obj), {}));
 
+const getPrezSystemLabel = (key: string) => {
+    const prezKeyLabelMapping = {
+        "VocPrez": "Vocabularies",
+        "SpacePrez": "Spatial Data",
+        "CatPrez": "Catalog Data"
+    }
+
+    if (key in prezKeyLabelMapping) {
+        return prezKeyLabelMapping[key];
+    }
+
+    return key
+}
+
 watch(() => route.path, (newValue) => {
     Object.keys(dropdowns.value).forEach(prez => dropdowns.value[prez] = prez === activePrez.value);
 });
@@ -89,7 +103,7 @@ const props = defineProps<{
             <template v-for="prez in enabledPrezs">
                 <div class="nav-item">
                     <RouterLink :to="`/${prez.toLowerCase()[0]}`" class="nav-link">
-                        {{ prez }}
+                        {{ getPrezSystemLabel(prez) }}
                     </RouterLink>
                     <button class="dropdown-btn" @click="dropdowns[prez] = !dropdowns[prez]">
                         <i :class="`fa-regular fa-chevron-${dropdowns[prez] ? 'up' : 'down'}`"></i>

--- a/src/components/navs/MainNav.vue
+++ b/src/components/navs/MainNav.vue
@@ -3,6 +3,7 @@ import { inject, computed, ref, watch } from "vue";
 import { RouterLink, useRoute } from "vue-router";
 import { useUiStore } from "@/stores/ui";
 import { enabledPrezsConfigKey, type PrezFlavour } from "@/types";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const routes: {[key: string]: any[]} = {
     "VocPrez": [
@@ -71,20 +72,6 @@ const activePrez = computed(() => {
 
 const collapse = ref(false);
 const dropdowns = ref(enabledPrezs.value.reduce<{[key: string]: boolean}>((obj, prez) => (obj[prez] = prez === activePrez.value, obj), {}));
-
-const getPrezSystemLabel = (key: string) => {
-    const prezKeyLabelMapping = {
-        "VocPrez": "Vocabularies",
-        "SpacePrez": "Spatial Data",
-        "CatPrez": "Catalog Data"
-    }
-
-    if (key in prezKeyLabelMapping) {
-        return prezKeyLabelMapping[key];
-    }
-
-    return key
-}
 
 watch(() => route.path, (newValue) => {
     Object.keys(dropdowns.value).forEach(prez => dropdowns.value[prez] = prez === activePrez.value);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -37,7 +37,7 @@ const router = createRouter({
             name: "vocabs",
             component: () => import("@/views/ItemListView.vue"),
             props: {
-                title: "Vocabs",
+                title: "Vocabularies",
                 class: "skos:ConceptScheme",
                 enableSearch: true,
                 content: `A list of <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme" target="_blank" rel="noopener noreferrer">skos:ConceptSchemes</a>.`

--- a/src/util/prezSystemLabelMapping.ts
+++ b/src/util/prezSystemLabelMapping.ts
@@ -1,8 +1,8 @@
 const getPrezSystemLabel = (key: string) => {
   const prezKeyLabelMapping: { [key: string]: string } = {
     VocPrez: "Vocabularies",
-    SpacePrez: "Spatial Data",
-    CatPrez: "Catalog Data",
+    SpacePrez: "Spatial Data Catalog",
+    CatPrez: "Data Catalog",
   };
 
   if (key in prezKeyLabelMapping) {

--- a/src/util/prezSystemLabelMapping.ts
+++ b/src/util/prezSystemLabelMapping.ts
@@ -1,0 +1,15 @@
+const getPrezSystemLabel = (key: string) => {
+  const prezKeyLabelMapping: { [key: string]: string } = {
+    VocPrez: "Vocabularies",
+    SpacePrez: "Spatial Data",
+    CatPrez: "Catalog Data",
+  };
+
+  if (key in prezKeyLabelMapping) {
+    return prezKeyLabelMapping[key];
+  }
+
+  return key;
+};
+
+export { getPrezSystemLabel };

--- a/src/util/sparqlExamples.ts
+++ b/src/util/sparqlExamples.ts
@@ -24,7 +24,7 @@ WHERE {
 } LIMIT 10`
     },
     {
-        title: "VocPrez Counting Concepts",
+        title: "Vocabularies - Counting Concepts",
         shortTitle: "Concept Count",
         description: "Here is an example query for VocPrez you can copy 'n paste into the Query UI text area above to test with. It counts the number of vocabulary Concepts in the all vocabularies in this system and will return an integer: ",
         query: `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -35,7 +35,7 @@ WHERE {
 }`
     },
     {
-        title: "SpacePrez Basic Feature Information",
+        title: "Spatial Data Catalog - Basic Feature Information",
         shortTitle: "Feature Info",
         description: "Here is an example query for SpacePrez for use in the Query UI above. It returns most two Features' URIs and their titles.",
         query: `PREFIX dcterms: <http://purl.org/dc/terms/>

--- a/src/views/DocsView.vue
+++ b/src/views/DocsView.vue
@@ -8,14 +8,14 @@ const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 
 onMounted(() => {
     ui.rightNavConfig = { enabled: false };
-    document.title = "API Docs | Prez";
+    document.title = "API Documentation | Prez";
     ui.pageHeading = { name: "Prez", url: "/"};
-    ui.breadcrumbs = [{ name: "API Docs", url: "/docs" }];
+    ui.breadcrumbs = [{ name: "API Documentation", url: "/docs" }];
 });
 </script>
 
 <template>
-    <h1 class="page-title">API Docs</h1>
+    <h1 class="page-title">API Documentation</h1>
     <p>This page lists the available endpoints of the Prez API for this instance.</p>
     <iframe :src="`${apiBaseUrl}/docs`" frameborder="0" name="docs" title="Prez API Swagger Docs"></iframe>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -18,20 +18,19 @@ onMounted(() => {
 
 <template>
     <h1 class="page-title">Welcome to Prez</h1>
-    <p>Prez is a Linked Data API that combines VocPrez, SpacePrez (OGC API) and CatPrez.</p>
-    <p>Each instance of Prez can either act as a collection of *Prezs or as a stand-alone instance of a single *Prez.</p>
+    <p>Prez is a Linked Data API with support for multiple data formats (JSON, CSV, JSON-LD, Turtle, RDF/XML).</p>
     <div class="prez-card-container">
         <RouterLink v-if="enabledPrezs.includes('CatPrez')" class="prez-card" to="/c">
-            <h3>CatPrez</h3>
-            <p>CatPrez presents Data Catalog Vocabulary (DCAT) catalogue information in RDF, in various formats.</p>
+            <h3>Data Catalog</h3>
+            <p>General data catalog structured using DCAT metadata format.</p>
         </RouterLink>
         <RouterLink v-if="enabledPrezs.includes('SpacePrez')" class="prez-card" to="/s">
-            <h3>SpacePrez</h3>
-            <p>SpacePrez presents GeoSPARQL spatial features in various formats. This API conforms to the Open Geospatial Consortium (OGC) API specification.</p>
+            <h3>Spatial Data Catalog</h3>
+            <p>Spatial data catalog of GeoSPARQL spatial features with an API conforming to the OGC API specification. Uses DCAT for catalog metadata.</p>
         </RouterLink>
         <RouterLink v-if="enabledPrezs.includes('VocPrez')" class="prez-card" to="/v">
-            <h3>VocPrez</h3>
-            <p>VocPrez presents Simple Knowledge Organization System (SKOS)-formulated RDF vocabularies in various formats.</p>
+            <h3>Vocabularies</h3>
+            <p>A well-structured set of SKOS vocabularies conforming to the VocPub profile.</p>
         </RouterLink>
     </div>
 </template>

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -11,6 +11,7 @@ import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
 import ProfilesTable from "@/components/ProfilesTable.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
 import PaginationComponent from "@/components/PaginationComponent.vue";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const { namedNode } = DataFactory;
 
@@ -56,7 +57,7 @@ const currentPageNumber = computed(() => {
 function getBreadcrumbs(): Breadcrumb[] {
     let breadcrumbs: Breadcrumb[] = [];
     if (flavour.value) {
-        breadcrumbs.push({ name: flavour.value, url: `/${flavour.value[0].toLowerCase()}`});
+        breadcrumbs.push({ name: getPrezSystemLabel(flavour.value) + " Home", url: `/${flavour.value[0].toLowerCase()}`});
         if (props.parentType) {
             if (["dcat:Dataset", "geo:FeatureCollection"].includes(props.parentType)) {
                 breadcrumbs.push({ name: "Datasets", url: "/s/datasets" });

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -11,6 +11,7 @@ import ConceptComponent from "@/components/ConceptComponent.vue";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
 import ProfilesTable from "@/components/ProfilesTable.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const { namedNode } = DataFactory;
 
@@ -220,7 +221,7 @@ function getChildren() {
 function getBreadcrumbs(): Breadcrumb[] {
     let breadcrumbs: Breadcrumb[] = [];
     if (flavour.value) {
-        breadcrumbs.push({ name: flavour.value, url: `/${flavour.value[0].toLowerCase()}`});
+        breadcrumbs.push({ name: getPrezSystemLabel(flavour.value) + " Home", url: `/${flavour.value[0].toLowerCase()}`});
         if (["ConceptInCollection"].includes(props.type)) {
             breadcrumbs.push({ name: "Collections", url: "/v/collection" });
         }

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -231,7 +231,7 @@ function getBreadcrumbs(): Breadcrumb[] {
             breadcrumbs.push({ name: "Vocabularies", url: "/v/vocab" });
         }
         if (["skos:Concept"].includes(props.type)) {
-            breadcrumbs.push({ name: "Vocab", url: `/v/vocab/${route.params.vocabId}` }); // need parent info in data (link, title & type)
+            breadcrumbs.push({ name: "Vocabulary", url: `/v/vocab/${route.params.vocabId}` }); // need parent info in data (link, title & type)
         }
         if (["skos:Collection"].includes(props.type)) {
             breadcrumbs.push({ name: "Collections", url: "/v/collection" });

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -228,7 +228,7 @@ function getBreadcrumbs(): Breadcrumb[] {
             breadcrumbs.push({ name: "Collection", url: `/v/collection/${route.params.collectionId}` });
         }
         if (["skos:ConceptScheme", "skos:Concept"].includes(props.type)) {
-            breadcrumbs.push({ name: "Vocabs", url: "/v/vocab" });
+            breadcrumbs.push({ name: "Vocabularies", url: "/v/vocab" });
         }
         if (["skos:Concept"].includes(props.type)) {
             breadcrumbs.push({ name: "Vocab", url: `/v/vocab/${route.params.vocabId}` }); // need parent info in data (link, title & type)

--- a/src/views/SparqlView.vue
+++ b/src/views/SparqlView.vue
@@ -169,15 +169,15 @@ function copy(text: string) {
 
 <template>
     <h1 class="page-title">SPARQL Search</h1>
-    <p>Here you can perform more advanced querying using <a href="https://www.w3.org/TR/sparql11-query/" target="_blank" rel="noopener noreferrer">SPARQL</a> (SPARQL Protocol and RDF Query Language). This page acts both as an interactive querying page as well as an endpoint for clients.</p>
+    <p>Perform advanced querying using <a href="https://www.w3.org/TR/sparql11-query/" target="_blank" rel="noopener noreferrer">SPARQL</a>. This page acts both as an interactive querying page as well as an endpoint for clients.</p>
     <div id="query-options" ref="queryOptionsElement">
         <div class="query-option">
             <div class="query-option-title">Endpoint</div>
             <select name="endpoint" id="endpoint" @change="selectedEndpoint = ($event.target as HTMLInputElement).value">
                 <option value="all" :selected="selectedEndpoint === 'all'">All</option>
-                <option value="catprez" :selected="selectedEndpoint === 'catprez'">CatPrez</option>
-                <option value="spaceprez" :selected="selectedEndpoint === 'spaceprez'">SpacePrez</option>
-                <option value="vocprez" :selected="selectedEndpoint === 'vocprez'">VocPrez</option>
+                <option value="catprez" :selected="selectedEndpoint === 'catprez'">Data Catalog</option>
+                <option value="spaceprez" :selected="selectedEndpoint === 'spaceprez'">Spatial Data Catalog</option>
+                <option value="vocprez" :selected="selectedEndpoint === 'vocprez'">Vocabularies</option>
             </select>
         </div>
         <div v-if="queryType === 'SELECT' || queryType === 'ASK'" class="query-option">

--- a/src/views/catprez/CatPrezAboutView.vue
+++ b/src/views/catprez/CatPrezAboutView.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { onMounted } from "vue";
 import { useUiStore } from "@/stores/ui";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const ui = useUiStore();
 
@@ -8,7 +9,7 @@ onMounted(() => {
     ui.rightNavConfig = { enabled: false };
     document.title = "About CatPrez | Prez";
     ui.pageHeading = { name: "CatPrez", url: "/c" };
-    ui.breadcrumbs = [{ name: "CatPrez", url: "/c" }, { name: "About", url: "/c/about" }];
+    ui.breadcrumbs = [{ name: getPrezSystemLabel("CatPrez") + " Home", url: "/c" }, { name: "About", url: "/c/about" }];
 });
 </script>
 

--- a/src/views/catprez/CatPrezHomeView.vue
+++ b/src/views/catprez/CatPrezHomeView.vue
@@ -12,6 +12,11 @@ const links = [
 
 <template>
     <FlavourHome flavour="CatPrez" :links="links">
+        <p>
+            A catalog of general data conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a>, delivered 
+            as a read-only web system in both human and machine-readable views.
+            The views are known as profiles and a list of them are available <RouterLink to="/s/profiles">here</RouterLink>.
+        </p>
         <p>Welcome to CatPrez - a read-only web delivery system for Data Catalog Vocabulary (DCAT) information.</p>
     </FlavourHome>
 </template>

--- a/src/views/catprez/CatPrezHomeView.vue
+++ b/src/views/catprez/CatPrezHomeView.vue
@@ -13,7 +13,7 @@ const links = [
 <template>
     <FlavourHome flavour="CatPrez" :links="links">
         <p>
-            A catalog of general data conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a>, delivered 
+            A general data catalog conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a>, delivered 
             as a read-only web system in both human and machine-readable views.
             The views are known as profiles and a list of them are available <RouterLink to="/s/profiles">here</RouterLink>.
         </p>

--- a/src/views/spaceprez/ConformanceView.vue
+++ b/src/views/spaceprez/ConformanceView.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { onMounted } from "vue";
 import { useUiStore } from "@/stores/ui";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const ui = useUiStore();
 
@@ -8,7 +9,7 @@ onMounted(() => {
     ui.rightNavConfig = { enabled: false };
     document.title = "Conformance | Prez";
     ui.pageHeading = { name: "SpacePrez", url: "/s"};
-    ui.breadcrumbs = [{ name: "SpacePrez", url: "/s" }, { name: "Conformance", url: "/c/conformance" }];
+    ui.breadcrumbs = [{ name: getPrezSystemLabel("SpacePrez") + " Home", url: "/s" }, { name: "Conformance", url: "/c/conformance" }];
 });
 </script>
 

--- a/src/views/spaceprez/SpacePrezAboutView.vue
+++ b/src/views/spaceprez/SpacePrezAboutView.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { onMounted } from "vue";
 import { useUiStore } from "@/stores/ui";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const ui = useUiStore();
 
@@ -8,7 +9,7 @@ onMounted(() => {
     ui.rightNavConfig = { enabled: false };
     document.title = "About SpacePrez | Prez";
     ui.pageHeading = { name: "SpacePrez", url: "/s" };
-    ui.breadcrumbs = [{ name: "SpacePrez", url: "/s" }, { name: "About", url: "/s/about" }];
+    ui.breadcrumbs = [{ name: getPrezSystemLabel("SpacePrez") + " Home", url: "/s" }, { name: "About", url: "/s/about" }];
 });
 </script>
 

--- a/src/views/spaceprez/SpacePrezHomeView.vue
+++ b/src/views/spaceprez/SpacePrezHomeView.vue
@@ -2,20 +2,27 @@
 import { onMounted } from "vue";
 import { useUiStore } from "@/stores/ui";
 import SpacePrezSearchMap from "@/components/search/SpacePrezSearchMap.vue";
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
 const ui = useUiStore();
 
 onMounted(() => {
     ui.rightNavConfig = { enabled: false };
-    document.title = "SpacePrez | Prez";
+    document.title = "Spatial Data Home | Prez";
     ui.pageHeading = { name: "SpacePrez", url: "/s"};
-    ui.breadcrumbs = [{ name: "SpacePrez", url: "/s" }];
+    ui.breadcrumbs = [{ name: getPrezSystemLabel("SpacePrez") + " Home", url: "/s" }];
 });
 </script>
 
 <template>
-    <h1>SpacePrez Home</h1>
-    <p>Welcome to SpacePrez</p>
+    <h1>Spatial Data</h1>
+    <p>
+        A spatial catalog of features conforming to DCAT and GeoSPARQL, delivered in both human and machine-readable views. 
+    </p>
+    <p>
+        The system provides a set of RDF APIs and also an OGC API for Feature Collections and Features.
+        See the <RouterLink to="/docs">API Documentation</RouterLink> for more information.
+    </p>
     <SpacePrezSearchMap />
 </template>
 

--- a/src/views/spaceprez/SpacePrezHomeView.vue
+++ b/src/views/spaceprez/SpacePrezHomeView.vue
@@ -8,14 +8,14 @@ const ui = useUiStore();
 
 onMounted(() => {
     ui.rightNavConfig = { enabled: false };
-    document.title = "Spatial Data Home | Prez";
+    document.title = "Spatial Data Catalog Home | Prez";
     ui.pageHeading = { name: "SpacePrez", url: "/s"};
     ui.breadcrumbs = [{ name: getPrezSystemLabel("SpacePrez") + " Home", url: "/s" }];
 });
 </script>
 
 <template>
-    <h1>Spatial Data</h1>
+    <h1>Spatial Data Catalog</h1>
     <p>
         A spatial catalog of Feature Collections and Features conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a> and 
         <a href="https://www.ogc.org/standard/geosparql/">GeoSPARQL</a>, and delivered as a read-only web system in both human and machine-readable views.

--- a/src/views/spaceprez/SpacePrezHomeView.vue
+++ b/src/views/spaceprez/SpacePrezHomeView.vue
@@ -17,7 +17,9 @@ onMounted(() => {
 <template>
     <h1>Spatial Data</h1>
     <p>
-        A spatial catalog of features conforming to DCAT and GeoSPARQL, delivered in both human and machine-readable views. 
+        A spatial catalog of Feature Collections and Features conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a> and 
+        <a href="https://www.ogc.org/standard/geosparql/">GeoSPARQL</a>, and delivered as a read-only web system in both human and machine-readable views.
+        The views are known as profiles and a list of them are available <RouterLink to="/s/profiles">here</RouterLink>.
     </p>
     <p>
         The system provides a set of RDF APIs and also an OGC API for Feature Collections and Features.

--- a/src/views/vocprez/VocPrezAboutView.vue
+++ b/src/views/vocprez/VocPrezAboutView.vue
@@ -8,7 +8,7 @@ onMounted(() => {
     ui.rightNavConfig = { enabled: false };
     document.title = "About VocPrez | Prez";
     ui.pageHeading = { name: "VocPrez", url: "/v" };
-    ui.breadcrumbs = [{ name: "VocPrez", url: "/v" }, { name: "About", url: "/v/about" }];
+    ui.breadcrumbs = [{ name: "Vocabularies Home", url: "/v" }, { name: "About", url: "/v/about" }];
 });
 </script>
 

--- a/src/views/vocprez/VocPrezHomeView.vue
+++ b/src/views/vocprez/VocPrezHomeView.vue
@@ -18,35 +18,42 @@ const links = [
 
 <template>
     <FlavourHome flavour="VocPrez" :links="links">
-        <p>Welcome to VocPrez - a read-only web delivery system for Simple Knowledge Organization System (SKOS)-formulated
-            RDF vocabularies.</p>
-        <p>VocPrez presents different views of vocabularies from a list of RDF sources. This system currently implements
-            sources from local files, Research Vocabularies Australia and VocBench.</p>
-        <h2>Vocabularies</h2>
         <p>
-            Vocabularies (or ConceptSchemes) contain a hierarchical list of terms (or Concepts).
+            The vocabularies are provided as a read-only web delivery system, providing a standardised set of profiles 
+            in both human and machine-readable views. See the available profiles <RouterLink to="/v/profiles">here</RouterLink>.
         </p>
         <p>
-            See the <RouterLink to="/v/vocab">Vocabularies Register</RouterLink> for a list of vocabularies this
-            instance of VocPrez knows about.
+            More specifically, the vocabularies defined in this system conform to the VocPub profile,
+            which itself is an opinionated profile of the SKOS (Simple Knowledge Organisation System) data model.
+        </p>
+        <h2>Vocabularies</h2>
+        <p>
+            A vocabulary (concept scheme) is a hierarchical list of terms (concepts).
+        </p>
+        <p>
+            See the <RouterLink to="/v/vocab">Vocabularies Register</RouterLink> for a list of vocabularies.
         </p>
         <h2>Collections</h2>
         <p>
-            Collections are a grouping of terms (or Concepts), represented as a flat listing of Concepts.
+            A collectionis a flat grouping of terms (concepts).
         </p>
         <p>
-            See the <RouterLink to="/v/collection">Collections page</RouterLink> for a list of collections this
-            instance of VocPrez knows about.
+            See the <RouterLink to="/v/collection">Collections page</RouterLink> for a list of collections.
         </p>
         <h2>Concepts</h2>
         <p>
-            Vocabulary terms (or Concepts) are listed within a vocabulary's home page. Each vocabulary presents both a
+            Vocabulary terms (concepts) are listed within a vocabulary's home page. Each vocabulary presents both a
             concept hierarchy (tree) view and a link to a flat list of its concepts.
         </p>
         <h2>Search and Querying</h2>
         <p>
-            You can search for Concepts within one vocab or across all vocabularies by using the search bar below or the <RouterLink to="/search">Advanced Search page</RouterLink>, or perform SPARQL queries using the <RouterLink to="/sparql">SPARQL page</RouterLink>.
+            You can search for concepts within one vocabulary or across all vocabularies.
         </p>
+        <ul>
+            <li>To search across vocabularies, use the search bar above.</li>
+            <li>To search across the entire Prez system, use the <RouterLink to="/search">Advanced Search</RouterLink>.</li>
+            <li>To perform custom queries, use the SPARQL query language on the <RouterLink to="/sparql">SPARQL page</RouterLink></li>
+        </ul>
 </FlavourHome></template>
 
 <style lang="scss" scoped></style>

--- a/src/views/vocprez/VocPrezHomeView.vue
+++ b/src/views/vocprez/VocPrezHomeView.vue
@@ -4,7 +4,7 @@ import FlavourHome from "@/components/FlavourHome.vue";
 
 const links = [
     {
-        label: "Vocabs",
+        label: "Vocabularies",
         url: "/v/vocab",
         description: "A list of SKOS vocabularies"
     },
@@ -43,9 +43,9 @@ const links = [
             Vocabulary terms (or Concepts) are listed within a vocabulary's home page. Each vocabulary presents both a
             concept hierarchy (tree) view and a link to a flat list of its concepts.
         </p>
-        <h2>Search & Querying</h2>
+        <h2>Search and Querying</h2>
         <p>
-            You can search for Concepts within one vocab or across all vocabs by using the search bar below or the <RouterLink to="/search">Advanced Search page</RouterLink>, or perform SPARQL queries using the <RouterLink to="/sparql">SPARQL page</RouterLink>.
+            You can search for Concepts within one vocab or across all vocabularies by using the search bar below or the <RouterLink to="/search">Advanced Search page</RouterLink>, or perform SPARQL queries using the <RouterLink to="/sparql">SPARQL page</RouterLink>.
         </p>
 </FlavourHome></template>
 

--- a/src/views/vocprez/VocPrezHomeView.vue
+++ b/src/views/vocprez/VocPrezHomeView.vue
@@ -35,7 +35,7 @@ const links = [
         </p>
         <h2>Collections</h2>
         <p>
-            A collectionis a flat grouping of terms (concepts).
+            A collection is a flat grouping of terms (concepts).
         </p>
         <p>
             See the <RouterLink to="/v/collection">Collections page</RouterLink> for a list of collections.


### PR DESCRIPTION
Use more common/general terminology such as vocabularies, catalogs, etc instead of subsystem names (VocPrez, etc). 

This change is made to ensure Prez as a piece of software is more approachable to a wider range of users, including those that do not have a technical/semantic background.

Since the current implementation couples the key of the subsystem to the breadcrumbs labelling display, I've introduced a lookup function go from key to label called `getPrezSystemLabel`.