### PR TITLE
Add item listing table with metadata

### DIFF
--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -46,69 +46,29 @@ const setSortState = (key: listingTableColumn) => {
     }
 }
 
-// props.items.sort((a, b) => a.status?.localeCompare(b.status))
-
-watch(sortState, (newSortState, oldSortState) => {
+watch(sortState, () => {
     const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
+    const keyToListItem = {
+        label: "title",
+        description: "description",
+        status: "status",
+        derivationMode: "derivationMode",
+    }
     
-
     for (const validKey of validKeys) {
-        if (validKey === "label" && sortState[validKey] === true) {
+        if (sortState[validKey] === true) {
             rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (a.hasOwnProperty("title")) {
-                    return a.title.localeCompare(b.title)
+                const listItemKey = keyToListItem[validKey];
+                if (a.hasOwnProperty(listItemKey)) {
+                    return a[listItemKey].localeCompare(b[listItemKey]);
                 }
             })
         }
-        else if (validKey === "label" && sortState[validKey] === false) {
+        else if (sortState[validKey] === false) {
             rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (b.hasOwnProperty("title")) {
-                    return b.title.localeCompare(a.title)
-                }
-            })
-        }
-
-        else if (validKey === "description" && sortState[validKey] === true) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (a.hasOwnProperty("description")) {
-                    return a.description.localeCompare(b.description)
-                }
-            })
-        }
-        else if (validKey === "description" && sortState[validKey] === false) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (b.hasOwnProperty("description")) {
-                    return b.description.localeCompare(a.description)
-                }
-            })
-        }
-
-        else if (validKey === "status" && sortState[validKey] === true) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (a.hasOwnProperty("status")) {
-                    return a.status.localeCompare(b.status)
-                }
-            })
-        }
-        else if (validKey === "status" && sortState[validKey] === false) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (b.hasOwnProperty("status")) {
-                    return b.status.localeCompare(a.status)
-                }
-            })
-        }
-
-        else if (validKey === "derivationMode" && sortState[validKey] === true) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (a.hasOwnProperty("derivationMode")) {
-                    return a.derivationMode.localeCompare(b.derivationMode)
-                }
-            })
-        }
-        else if (validKey === "derivationMode" && sortState[validKey] === false) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                if (b.hasOwnProperty("derivationMode")) {
-                    return b.derivationMode.localeCompare(a.derivationMode)
+                const listItemKey = keyToListItem[validKey];
+                if (b.hasOwnProperty(listItemKey)) {
+                    return b[listItemKey].localeCompare(a[listItemKey]);
                 }
             })
         }

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -11,6 +11,10 @@ const props = defineProps<{
     childLink?: string;
 }>();
 
+// Each key is a table header.
+// If key has the value "true", it is being sorted alphabetically A-Z.
+// If key has the value "false", it is being sorted alphabetically Z-A.
+// Only one key can have a value of true or false and other keys are null.
 const sortState = reactive<{label: boolean | null, description: boolean | null, status: boolean | null, derivationMode: boolean | null}>({
     label: true,
     description: null,

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -1,22 +1,130 @@
 <script lang="ts" setup>
+import { reactive, watch, ref } from "vue";
 import { RouterLink } from "vue-router";
-import type { ListItem } from "@/types";
+
+import ItemListSortButton from "@/components/ItemListSortButton.vue";
+import type { ListItem, listingTableColumn } from "@/types";
 
 const props = defineProps<{
     items: ListItem[];
     childName?: string;
     childLink?: string;
 }>();
+
+const sortState = reactive<{label: boolean | null, description: boolean | null, status: boolean | null, derivationMode: boolean | null}>({
+    label: true,
+    description: null,
+    status: null,
+    derivationMode: null
+});
+
+const rows = ref(props.items);
+
+const setSortState = (key: listingTableColumn) => {
+    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
+    
+    // Save the current value.
+    const currentKeyValue = sortState[key];
+
+    // Set all the values to null.
+    for (const validKey of validKeys) {
+        sortState[validKey] = null;
+    }
+
+    if (typeof currentKeyValue === "boolean") {
+        if (currentKeyValue === true) {
+            sortState[key] = false;
+        } 
+        else if (currentKeyValue === false) {
+            sortState[key] = true;
+        } else {
+            sortState[key] = null;
+        }
+    }
+    else {
+        sortState[key] = true;
+    }
+}
+
+// props.items.sort((a, b) => a.status?.localeCompare(b.status))
+
+watch(sortState, (newSortState, oldSortState) => {
+    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
+    
+
+    for (const validKey of validKeys) {
+        if (validKey === "label" && sortState[validKey] === true) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (a.hasOwnProperty("title")) {
+                    return a.title.localeCompare(b.title)
+                }
+            })
+        }
+        else if (validKey === "label" && sortState[validKey] === false) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (b.hasOwnProperty("title")) {
+                    return b.title.localeCompare(a.title)
+                }
+            })
+        }
+
+        else if (validKey === "description" && sortState[validKey] === true) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (a.hasOwnProperty("description")) {
+                    return a.description.localeCompare(b.description)
+                }
+            })
+        }
+        else if (validKey === "description" && sortState[validKey] === false) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (b.hasOwnProperty("description")) {
+                    return b.description.localeCompare(a.description)
+                }
+            })
+        }
+
+        else if (validKey === "status" && sortState[validKey] === true) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (a.hasOwnProperty("status")) {
+                    return a.status.localeCompare(b.status)
+                }
+            })
+        }
+        else if (validKey === "status" && sortState[validKey] === false) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (b.hasOwnProperty("status")) {
+                    return b.status.localeCompare(a.status)
+                }
+            })
+        }
+
+        else if (validKey === "derivationMode" && sortState[validKey] === true) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (a.hasOwnProperty("derivationMode")) {
+                    return a.derivationMode.localeCompare(b.derivationMode)
+                }
+            })
+        }
+        else if (validKey === "derivationMode" && sortState[validKey] === false) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                if (b.hasOwnProperty("derivationMode")) {
+                    return b.derivationMode.localeCompare(a.derivationMode)
+                }
+            })
+        }
+    }
+});
+
 </script>
 
 <template>
     <table class="table" role="grid">
         <thead>
             <tr role="row">
-                <th>Label</th>
-                <th>Description</th>
-                <th>Status</th>
-                <th>Derivation mode</th>
+                <th>Label <ItemListSortButton id="label" :state="sortState.label" @clicked="(id) => setSortState(id)" /></th>
+                <th>Description <ItemListSortButton id="description" :state="sortState.description" @clicked="(id) => setSortState(id)" /></th>
+                <th>Status <ItemListSortButton id="status" :state="sortState.status" @clicked="(id) => setSortState(id)" /></th>
+                <th>Derivation mode <ItemListSortButton id="derivationMode" :state="sortState.derivationMode" @clicked="(id) => setSortState(id)" /></th>
             </tr>
         </thead>
         <tbody>
@@ -33,7 +141,7 @@ const props = defineProps<{
                     <div v-if="!!item.status">{{  item.status }}</div>
                 </td>
                 <td>
-                    <div v-if="!!item.role">{{  item.role }}</div>
+                    <div v-if="!!item.derivationMode">{{  item.derivationMode }}</div>
                 </td>
             </tr>
         </tbody>

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -135,14 +135,10 @@ td {
 }
 
 .list {
-    // display: flex;
-    // flex-direction: column;
     gap: 12px;
     margin-bottom: 12px;
 
     a.list-item {
-        // display: flex;
-        // flex-direction: row;
         gap: 10px;
         background-color: var(--cardBg);
         padding: 10px;

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -125,6 +125,11 @@ watch(sortState, () => {
     background-color: var(--cardBg);
 }
 
+th {
+    text-align: left;
+    padding-left: 0.5rem;
+}
+
 td {
     padding: 10px;
 }

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -10,29 +10,62 @@ const props = defineProps<{
 </script>
 
 <template>
-    <div class="list">
-        <RouterLink class="list-item" v-for="item in props.items" :to="!!item.link ? item.link : ''">
-            <div class="list-item-left">
-                <h4 class="list-item-title">{{ item.title || item.iri }}</h4>
-                <div v-if="!!item.description" class="list-item-desc">{{ item.description }}</div>
-            </div>
-            <RouterLink v-if="props.childLink" @click.stop :to="item.link + props.childLink" class="btn outline sm child-btn">{{ props.childName }}</RouterLink>
-        </RouterLink>
-    </div>
+    <table class="table" role="grid">
+        <thead>
+            <tr role="row">
+                <th>Label</th>
+                <th>Description</th>
+                <th>Status</th>
+                <th>Derivation mode</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="row" role="row" v-for="item in props.items">
+                <td>
+                    <RouterLink :to="!!item.link ? item.link : ''">
+                        {{ item.title || item.iri }}
+                    </RouterLink>
+                </td>
+                <td>
+                    <div v-if="!!item.description">{{ item.description.substring(0, 80) + "..." }}</div>
+                </td>
+                <td>
+                    <div v-if="!!item.status">{{  item.status }}</div>
+                </td>
+                <td>
+                    <div v-if="!!item.role">{{  item.role }}</div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
 </template>
 
 <style lang="scss" scoped>
 @import "@/assets/sass/_variables.scss";
 
+.table {
+    border-collapse: separate;
+    border-spacing: 0 1em;
+}
+
+.row {
+    padding: 5px;
+    background-color: var(--cardBg);
+}
+
+td {
+    padding: 10px;
+}
+
 .list {
-    display: flex;
-    flex-direction: column;
+    // display: flex;
+    // flex-direction: column;
     gap: 12px;
-    margin-bottom: 12px;;
+    margin-bottom: 12px;
 
     a.list-item {
-        display: flex;
-        flex-direction: row;
+        // display: flex;
+        // flex-direction: row;
         gap: 10px;
         background-color: var(--cardBg);
         padding: 10px;

--- a/src/components/ItemList.vue
+++ b/src/components/ItemList.vue
@@ -1,144 +1,38 @@
 <script lang="ts" setup>
-import { reactive, watch, ref } from "vue";
 import { RouterLink } from "vue-router";
-
-import ItemListSortButton from "@/components/ItemListSortButton.vue";
-import type { ListItem, listingTableColumn } from "@/types";
+import type { ListItem } from "@/types";
 
 const props = defineProps<{
     items: ListItem[];
     childName?: string;
     childLink?: string;
 }>();
-
-// Each key is a table header.
-// If key has the value "true", it is being sorted alphabetically A-Z.
-// If key has the value "false", it is being sorted alphabetically Z-A.
-// Only one key can have a value of true or false and other keys are null.
-const sortState = reactive<{label: boolean | null, description: boolean | null, status: boolean | null, derivationMode: boolean | null}>({
-    label: true,
-    description: null,
-    status: null,
-    derivationMode: null
-});
-
-const rows = ref(props.items);
-
-const setSortState = (key: listingTableColumn) => {
-    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
-    
-    // Save the current value.
-    const currentKeyValue = sortState[key];
-
-    // Set all the values to null.
-    for (const validKey of validKeys) {
-        sortState[validKey] = null;
-    }
-
-    if (typeof currentKeyValue === "boolean") {
-        if (currentKeyValue === true) {
-            sortState[key] = false;
-        } 
-        else if (currentKeyValue === false) {
-            sortState[key] = true;
-        } else {
-            sortState[key] = null;
-        }
-    }
-    else {
-        sortState[key] = true;
-    }
-}
-
-watch(sortState, () => {
-    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
-    const keyToListItem = {
-        label: "title",
-        description: "description",
-        status: "status",
-        derivationMode: "derivationMode",
-    }
-    
-    for (const validKey of validKeys) {
-        if (sortState[validKey] === true) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                const listItemKey = keyToListItem[validKey];
-                if (a.hasOwnProperty(listItemKey)) {
-                    return a[listItemKey].localeCompare(b[listItemKey]);
-                }
-            })
-        }
-        else if (sortState[validKey] === false) {
-            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
-                const listItemKey = keyToListItem[validKey];
-                if (b.hasOwnProperty(listItemKey)) {
-                    return b[listItemKey].localeCompare(a[listItemKey]);
-                }
-            })
-        }
-    }
-});
-
 </script>
 
 <template>
-    <table class="table" role="grid">
-        <thead>
-            <tr role="row">
-                <th>Label <ItemListSortButton id="label" :state="sortState.label" @clicked="(id) => setSortState(id)" /></th>
-                <th>Description <ItemListSortButton id="description" :state="sortState.description" @clicked="(id) => setSortState(id)" /></th>
-                <th>Status <ItemListSortButton id="status" :state="sortState.status" @clicked="(id) => setSortState(id)" /></th>
-                <th>Derivation mode <ItemListSortButton id="derivationMode" :state="sortState.derivationMode" @clicked="(id) => setSortState(id)" /></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="row" role="row" v-for="item in props.items">
-                <td>
-                    <RouterLink :to="!!item.link ? item.link : ''">
-                        {{ item.title || item.iri }}
-                    </RouterLink>
-                </td>
-                <td>
-                    <div v-if="!!item.description">{{ item.description.substring(0, 80) + "..." }}</div>
-                </td>
-                <td>
-                    <div v-if="!!item.status">{{  item.status }}</div>
-                </td>
-                <td>
-                    <div v-if="!!item.derivationMode">{{  item.derivationMode }}</div>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    <div class="list">
+        <RouterLink class="list-item" v-for="item in props.items" :to="!!item.link ? item.link : ''">
+            <div class="list-item-left">
+                <h4 class="list-item-title">{{ item.title || item.iri }}</h4>
+                <div v-if="!!item.description" class="list-item-desc">{{ item.description }}</div>
+            </div>
+            <RouterLink v-if="props.childLink" @click.stop :to="item.link + props.childLink" class="btn outline sm child-btn">{{ props.childName }}</RouterLink>
+        </RouterLink>
+    </div>
 </template>
 
 <style lang="scss" scoped>
 @import "@/assets/sass/_variables.scss";
 
-.table {
-    border-collapse: separate;
-    border-spacing: 0 1em;
-}
-
-.row {
-    padding: 5px;
-    background-color: var(--cardBg);
-}
-
-th {
-    text-align: left;
-    padding-left: 0.5rem;
-}
-
-td {
-    padding: 10px;
-}
-
 .list {
+    display: flex;
+    flex-direction: column;
     gap: 12px;
-    margin-bottom: 12px;
+    margin-bottom: 12px;;
 
     a.list-item {
+        display: flex;
+        flex-direction: row;
         gap: 10px;
         background-color: var(--cardBg);
         padding: 10px;

--- a/src/components/ItemListSortButton.vue
+++ b/src/components/ItemListSortButton.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import type { listingTableColumn } from "@/types";
+
+defineProps<{
+  id: listingTableColumn;
+  state: boolean | null;
+}>();
+
+defineEmits(["clicked"]);
+</script>
+
+<template>
+  <span class="pointer" @click="$emit('clicked', id)">
+    <i v-if="state === true" class="fa-solid fa-arrow-up-a-z"></i>
+    <i v-else-if="state === false" class="fa-solid fa-arrow-down-z-a"></i>
+    <i v-else="" class="fa-thin fa-arrow-up-a-z"></i>
+  </span>
+</template>
+
+<style scoped>
+.pointer {
+  cursor: pointer;
+}
+</style>

--- a/src/components/VocabItemList.vue
+++ b/src/components/VocabItemList.vue
@@ -1,0 +1,170 @@
+<script lang="ts" setup>
+import { reactive, watch, ref } from "vue";
+import { RouterLink } from "vue-router";
+
+import ItemListSortButton from "@/components/ItemListSortButton.vue";
+import type { ListItem, listingTableColumn } from "@/types";
+
+const props = defineProps<{
+    items: ListItem[];
+    childName?: string;
+    childLink?: string;
+}>();
+
+// Each key is a table header.
+// If key has the value "true", it is being sorted alphabetically A-Z.
+// If key has the value "false", it is being sorted alphabetically Z-A.
+// Only one key can have a value of true or false and other keys are null.
+const sortState = reactive<{label: boolean | null, description: boolean | null, status: boolean | null, derivationMode: boolean | null}>({
+    label: true,
+    description: null,
+    status: null,
+    derivationMode: null
+});
+
+const rows = ref(props.items);
+
+const setSortState = (key: listingTableColumn) => {
+    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
+    
+    // Save the current value.
+    const currentKeyValue = sortState[key];
+
+    // Set all the values to null.
+    for (const validKey of validKeys) {
+        sortState[validKey] = null;
+    }
+
+    if (typeof currentKeyValue === "boolean") {
+        if (currentKeyValue === true) {
+            sortState[key] = false;
+        } 
+        else if (currentKeyValue === false) {
+            sortState[key] = true;
+        } else {
+            sortState[key] = null;
+        }
+    }
+    else {
+        sortState[key] = true;
+    }
+}
+
+watch(sortState, () => {
+    const validKeys: listingTableColumn[] = ["label", "description", "status", "derivationMode"];
+    const keyToListItem = {
+        label: "title",
+        description: "description",
+        status: "status",
+        derivationMode: "derivationMode",
+    }
+    
+    for (const validKey of validKeys) {
+        if (sortState[validKey] === true) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                const listItemKey = keyToListItem[validKey];
+                if (a.hasOwnProperty(listItemKey)) {
+                    return a[listItemKey].localeCompare(b[listItemKey]);
+                }
+            })
+        }
+        else if (sortState[validKey] === false) {
+            rows.value = props.items.sort((a: ListItem, b: ListItem) => {
+                const listItemKey = keyToListItem[validKey];
+                if (b.hasOwnProperty(listItemKey)) {
+                    return b[listItemKey].localeCompare(a[listItemKey]);
+                }
+            })
+        }
+    }
+});
+
+</script>
+
+<template>
+    <table class="table" role="grid">
+        <thead>
+            <tr role="row">
+                <th>Label <ItemListSortButton id="label" :state="sortState.label" @clicked="(id) => setSortState(id)" /></th>
+                <th>Description <ItemListSortButton id="description" :state="sortState.description" @clicked="(id) => setSortState(id)" /></th>
+                <th>Status <ItemListSortButton id="status" :state="sortState.status" @clicked="(id) => setSortState(id)" /></th>
+                <th>Derivation mode <ItemListSortButton id="derivationMode" :state="sortState.derivationMode" @clicked="(id) => setSortState(id)" /></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="row" role="row" v-for="item in props.items">
+                <td>
+                    <RouterLink :to="!!item.link ? item.link : ''">
+                        {{ item.title || item.iri }}
+                    </RouterLink>
+                </td>
+                <td>
+                    <div v-if="!!item.description">{{ item.description.substring(0, 80) + "..." }}</div>
+                </td>
+                <td>
+                    <div v-if="!!item.status">{{  item.status }}</div>
+                </td>
+                <td>
+                    <div v-if="!!item.derivationMode">{{  item.derivationMode }}</div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/sass/_variables.scss";
+
+.table {
+    border-collapse: separate;
+    border-spacing: 0 1em;
+}
+
+.row {
+    padding: 5px;
+    background-color: var(--cardBg);
+}
+
+th {
+    text-align: left;
+    padding-left: 0.5rem;
+}
+
+td {
+    padding: 10px;
+}
+
+.list {
+    gap: 12px;
+    margin-bottom: 12px;
+
+    a.list-item {
+        gap: 10px;
+        background-color: var(--cardBg);
+        padding: 10px;
+        border-radius: $borderRadius;
+
+        .list-item-left {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            flex-grow: 1;
+
+            .list-item-title {
+                margin: 0;
+            }
+
+            .list-item-desc {
+                font-style: italic;
+                color: grey;
+                font-size: 0.8rem;
+            }
+        }
+
+        .child-btn {
+            align-self: baseline;
+            flex-shrink: 0;
+        }
+    }
+}
+</style>

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,8 @@ export interface ListItem {
     description?: string;
     link?: string;
     type?: string;
+    status?: string;
+    role?: string;
 };
 
 export interface AnnotatedPredicate {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ import type { Quad } from "n3";
 
 export type PrezFlavour = "CatPrez" | "SpacePrez" | "VocPrez";
 
+export type listingTableColumn = "label" | "description" | "status" | "derivationMode";
+
 export const mapConfigKey: InjectionKey<MapConfig> = Symbol();
 export const sidenavConfigKey: InjectionKey<boolean> = Symbol();
 export const enabledPrezsConfigKey: InjectionKey<PrezFlavour[]> = Symbol();
@@ -90,7 +92,7 @@ export interface ListItem {
     link?: string;
     type?: string;
     status?: string;
-    role?: string;
+    derivationMode?: string;
 };
 
 export interface AnnotatedPredicate {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,14 @@ export interface ListItem {
     description?: string;
     link?: string;
     type?: string;
+};
+
+export interface VocabListItem {
+    iri: string;
+    title?: string;
+    description?: string;
+    link?: string;
+    type?: string;
     status?: string;
     derivationMode?: string;
 };

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -165,7 +165,7 @@ onMounted(() => {
                 } else if (q.predicate.value === qname("prov:qualifiedDerivation")) {
                     store.value.forObjects(result => {
                         store.value.forObjects(innerResult => {
-                            c.role = innerResult.value;
+                            c.derivationMode = innerResult.value;
                         }, result,qname("rdfs:label"), null);
                     }, q.object, qname("prov:hadRole"), null);
                 }

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -5,8 +5,9 @@ import { DataFactory, type Quad_Object, type Quad_Subject } from "n3";
 import { useUiStore } from "@/stores/ui";
 import { useRdfStore } from "@/composables/rdfStore";
 import { useGetRequest } from "@/composables/api";
-import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type PrezFlavour } from "@/types";
+import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type VocabListItem, type PrezFlavour } from "@/types";
 import ItemList from "@/components/ItemList.vue";
+import VocabItemList from "@/components/VocabItemList.vue";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
 import ProfilesTable from "@/components/ProfilesTable.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
@@ -149,29 +150,42 @@ onMounted(() => {
         }
 
         nodeList.forEach(member => {
-            let c: ListItem = {
-                iri: member.id
-            };
-            store.value.forEach(q => { // get preds & objs for each subj
-                if (q.predicate.value === labelPred) {
-                    c.title = q.object.value;
-                } else if (q.predicate.value === descPred) {
-                    c.description = q.object.value;
-                } else if (q.predicate.value === qname("prez:link")) {
-                    c.link = q.object.value;
-                } else if (q.predicate.value === qname("reg:status")) {
-                    store.value.forObjects(result => {
-                        c.status = result.value;
-                    }, q.object, qname("rdfs:label"), null);
-                } else if (q.predicate.value === qname("prov:qualifiedDerivation")) {
-                    store.value.forObjects(result => {
-                        store.value.forObjects(innerResult => {
-                            c.derivationMode = innerResult.value;
-                        }, result,qname("rdfs:label"), null);
-                    }, q.object, qname("prov:hadRole"), null);
-                }
-            }, member, null, null, null);
-            items.value.push(c);
+            let c: ListItem & VocabListItem = {iri: member.id};
+            
+            if (flavour.value === "VocPrez") {
+                store.value.forEach(q => { // get preds & objs for each subj
+                    if (q.predicate.value === labelPred) {
+                        c.title = q.object.value;
+                    } else if (q.predicate.value === descPred) {
+                        c.description = q.object.value;
+                    } else if (q.predicate.value === qname("prez:link")) {
+                        c.link = q.object.value;
+                    } else if (q.predicate.value === qname("reg:status")) {
+                        store.value.forObjects(result => {
+                            c.status = result.value;
+                        }, q.object, qname("rdfs:label"), null);
+                    } else if (q.predicate.value === qname("prov:qualifiedDerivation")) {
+                        store.value.forObjects(result => {
+                            store.value.forObjects(innerResult => {
+                                c.derivationMode = innerResult.value;
+                            }, result,qname("rdfs:label"), null);
+                        }, q.object, qname("prov:hadRole"), null);
+                    }
+                }, member, null, null, null);
+                items.value.push(c);
+            }
+            else {
+                store.value.forEach(q => { // get preds & objs for each subj
+                    if (q.predicate.value === labelPred) {
+                        c.title = q.object.value;
+                    } else if (q.predicate.value === descPred) {
+                        c.description = q.object.value;
+                    } else if (q.predicate.value === qname("prez:link")) {
+                        c.link = q.object.value;
+                    }
+                }, member, null, null, null);
+                items.value.push(c);
+            }
         });
 
         items.value.sort((a, b) => {
@@ -220,7 +234,12 @@ onMounted(() => {
             <i class="fa-regular fa-spinner-third fa-spin"></i> Loading...
         </template>
         <template v-else-if="items.length > 0">
-            <ItemList :items="items" :childName="props.childButton?.name" :childLink="props.childButton?.url" />
+            <template v-if="flavour === 'VocPrez'">
+                <VocabItemList :items="items" :childName="props.childButton?.name" :childLink="props.childButton?.url" />
+            </template>
+            <template v-else>
+                <ItemList :items="items" :childName="props.childButton?.name" :childLink="props.childButton?.url" />
+            </template>
             <PaginationComponent :url="route.path" :totalCount="count" :currentPage="currentPageNumber" />
         </template>
         <template v-else>No {{ props.title }} found.</template>

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -158,6 +158,16 @@ onMounted(() => {
                     c.description = q.object.value;
                 } else if (q.predicate.value === qname("prez:link")) {
                     c.link = q.object.value;
+                } else if (q.predicate.value === qname("reg:status")) {
+                    store.value.forObjects(result => {
+                        c.status = result.value;
+                    }, q.object, qname("rdfs:label"), null);
+                } else if (q.predicate.value === qname("prov:qualifiedDerivation")) {
+                    store.value.forObjects(result => {
+                        store.value.forObjects(innerResult => {
+                            c.role = innerResult.value;
+                        }, result,qname("rdfs:label"), null);
+                    }, q.object, qname("prov:hadRole"), null);
                 }
             }, member, null, null, null);
             items.value.push(c);


### PR DESCRIPTION
Displays the additional metadata defined in the updated VocPub profile made in https://github.com/RDFLib/prez/pull/102 for items listing page. This is displayed in a table with client-side ascending and descending alphabetical sorting.

Before and after screenshots.

![Screenshot 2023-05-05 at 8 54 52 pm](https://user-images.githubusercontent.com/37032744/236440115-0011c642-7f24-4436-b93e-8094637a1843.png)

![Screenshot 2023-05-05 at 8 55 01 pm](https://user-images.githubusercontent.com/37032744/236440142-839298a8-8477-434a-82fa-752c141777c9.png)
