### PR TITLE
Add typescript check on PR GitHub Action

### DIFF
--- a/.github/workflows/pr_tsc.yaml
+++ b/.github/workflows/pr_tsc.yaml
@@ -1,0 +1,27 @@
+name: PR - TypeScript check
+
+on:
+  # Make workflow callable.
+  workflow_call:
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        run: npm run type-check


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to run TypeScript check on PRs when it is opened, updated, and reopened.

The check is currently failing but once https://github.com/RDFLib/prez-ui/pull/52 is merged, it should pass fine.