### PR TITLE
List table view values display local name as fallback when labels are not available. Add missing reg prefix in useRdfStore.

### DIFF
--- a/src/composables/rdfStore.ts
+++ b/src/composables/rdfStore.ts
@@ -12,6 +12,7 @@ const defaultPrefixes: {[token: string]: string} = {
     "prov": "http://www.w3.org/ns/prov#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "reg": "http://purl.org/linked-data/registry#",
     "sdo": "https://schema.org/",
     "sh": "http://www.w3.org/ns/shacl#",
     "skos": "http://www.w3.org/2004/02/skos/core#",

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -83,6 +83,16 @@ function getSearchDefaults(): {[key: string]: string} { // need IRI of parent to
     }
 }
 
+function getIRILocalName(iri: string) {
+    let result = iri.split("#");
+    if (result.length === 1) {
+        return result[0].split("/").slice(-1)[0]
+    }
+    else {
+        return result.slice(-1)[0];
+    }
+}
+
 onMounted(() => {
     let paginationParams = "";
 
@@ -161,11 +171,13 @@ onMounted(() => {
                     } else if (q.predicate.value === qname("prez:link")) {
                         c.link = q.object.value;
                     } else if (q.predicate.value === qname("reg:status")) {
+                        c.status = getIRILocalName(q.object.value);
                         store.value.forObjects(result => {
                             c.status = result.value;
                         }, q.object, qname("rdfs:label"), null);
                     } else if (q.predicate.value === qname("prov:qualifiedDerivation")) {
                         store.value.forObjects(result => {
+                            c.derivationMode = getIRILocalName(result.value);
                             store.value.forObjects(innerResult => {
                                 c.derivationMode = innerResult.value;
                             }, result,qname("rdfs:label"), null);


### PR DESCRIPTION
The initial implementation of the listing table in https://github.com/RDFLib/prez-ui/pull/48 only displays the metadata values of **status** and **derivation mode** if the label is available.

This PR ensures that if there is a value, it is displayed even when a label is not available by falling back to using the local name of the IRI.

![Screenshot 2023-05-10 at 8 17 18 pm](https://github.com/RDFLib/prez-ui/assets/37032744/71c82d9e-9634-4d76-a86e-6508ffab39b2)

Additionally, this PR also adds the `reg` prefix to `useRdfStore`.