### PR TITLE
Fix getting latest tag in main_push.yaml workflow

### DIFF
--- a/.github/workflows/main_push.yaml
+++ b/.github/workflows/main_push.yaml
@@ -73,6 +73,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          # Required by WyriHaximus/github-action-get-previous-tag
+          fetch-depth: 0
 
       - name: Get latest tag
         id: latest-tag


### PR DESCRIPTION
The step that gets the latest git tag is currently using the fallback value instead because it can't find the git tags from the "Checkout repo" step.

To fix this, we need to tell `actions/checkout` to fetch with a depth of 0 to have the git tags available.

See the example here https://github.com/WyriHaximus/github-action-get-previous-tag#example which states that:

> fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags

This is why our dev images in https://github.com/RDFLib/prez-ui/pkgs/container/prez-ui are tagged with `0.1.1-dev.{commit-count}.{commit-sha}` at the moment.