### PR TITLE
Update vocab listing table for reg status and derivation mode

### DIFF
--- a/src/components/VocabItemList.vue
+++ b/src/components/VocabItemList.vue
@@ -104,7 +104,10 @@ watch(sortState, () => {
                     <div v-if="!!item.description">{{ item.description.substring(0, 80) + "..." }}</div>
                 </td>
                 <td>
-                    <div v-if="!!item.status">{{  item.status }}</div>
+                    <div v-if="!!item.status">
+                        <a :href="item.status.iri" target="_blank">{{ item.status.label }}</a>
+                        <span :style="`color: ${item.status.color}`" class="fa-solid fa-circle fa-2xs"></span>
+                    </div>
                 </td>
                 <td>
                     <div v-if="!!item.derivationMode">{{  item.derivationMode }}</div>

--- a/src/components/VocabItemList.vue
+++ b/src/components/VocabItemList.vue
@@ -105,8 +105,7 @@ watch(sortState, () => {
                 </td>
                 <td>
                     <div v-if="!!item.status">
-                        <a :href="item.status.iri" target="_blank">{{ item.status.label }}</a>
-                        <span :style="`color: ${item.status.color}`" class="fa-solid fa-circle fa-2xs"></span>
+                        <a :href="item.status.iri" target="_blank">{{ item.status.label }}</a> <span :style="`color: ${item.status.color}`" class="fa-solid fa-circle fa-2xs"></span>
                     </div>
                 </td>
                 <td>

--- a/src/components/VocabItemList.vue
+++ b/src/components/VocabItemList.vue
@@ -109,7 +109,9 @@ watch(sortState, () => {
                     </div>
                 </td>
                 <td>
-                    <div v-if="!!item.derivationMode">{{  item.derivationMode }}</div>
+                    <div v-if="!!item.derivationMode">
+                        <a :href="item.derivationMode.iri">{{  item.derivationMode.label }}</a>
+                    </div>
                 </td>
             </tr>
         </tbody>

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,15 +94,21 @@ export interface ListItem {
     type?: string;
 };
 
+export interface RegStatus {
+    iri: string;
+    label: string;
+    color?: string;
+};
+
 export interface VocabListItem {
     iri: string;
     title?: string;
     description?: string;
     link?: string;
     type?: string;
-    status?: string;
+    status?: RegStatus;
     derivationMode?: string;
-    [key: string]: string | undefined;
+    [key: string]: string | RegStatus | undefined;
 };
 
 export interface AnnotatedPredicate {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,11 @@ export interface RegStatus {
     color?: string;
 };
 
+export interface DerivationMode {
+    iri: string;
+    label: string;
+};
+
 export interface VocabListItem {
     iri: string;
     title?: string;
@@ -107,7 +112,7 @@ export interface VocabListItem {
     link?: string;
     type?: string;
     status?: RegStatus;
-    derivationMode?: string;
+    derivationMode?: DerivationMode;
     [key: string]: string | RegStatus | undefined;
 };
 

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -5,7 +5,7 @@ import { DataFactory, type Quad_Object, type Quad_Subject } from "n3";
 import { useUiStore } from "@/stores/ui";
 import { useRdfStore } from "@/composables/rdfStore";
 import { useGetRequest } from "@/composables/api";
-import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type VocabListItem, type PrezFlavour, type Profile, type RegStatus } from "@/types";
+import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type VocabListItem, type PrezFlavour, type Profile, type RegStatus, type DerivationMode } from "@/types";
 import ItemList from "@/components/ItemList.vue";
 import VocabItemList from "@/components/VocabItemList.vue";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
@@ -207,10 +207,13 @@ function getProperties() {
                 c.status = status;
             } else if (flavour.value === "VocPrez" && q.predicate.value === qname("prov:qualifiedDerivation")) {
                 store.value.forObjects(result => {
-                    c.derivationMode = getIRILocalName(result.value);
+                    const mode: DerivationMode = {iri: result.value, label: getIRILocalName(result.value)};
+
                     store.value.forObjects(innerResult => {
-                        c.derivationMode = innerResult.value;
+                        mode.label = innerResult.value;
                     }, result,qname("rdfs:label"), null);
+
+                    c.derivationMode = mode;
                 }, q.object, qname("prov:hadRole"), null);
             }
         }, member, null, null, null);

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -5,7 +5,7 @@ import { DataFactory, type Quad_Object, type Quad_Subject } from "n3";
 import { useUiStore } from "@/stores/ui";
 import { useRdfStore } from "@/composables/rdfStore";
 import { useGetRequest } from "@/composables/api";
-import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type VocabListItem, type PrezFlavour, type Profile } from "@/types";
+import { apiBaseUrlConfigKey, type Breadcrumb, type ListItem, type VocabListItem, type PrezFlavour, type Profile, type RegStatus } from "@/types";
 import ItemList from "@/components/ItemList.vue";
 import VocabItemList from "@/components/VocabItemList.vue";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
@@ -195,10 +195,16 @@ function getProperties() {
             } else if (q.predicate.value === qname("prez:link")) {
                 c.link = q.object.value;
             } else if (flavour.value === "VocPrez" && q.predicate.value === qname("reg:status")) {
-                c.status = getIRILocalName(q.object.value);
+                const status: RegStatus = {iri: q.object.value, label: getIRILocalName(q.object.value)};
+
                 store.value.forObjects(result => {
-                    c.status = result.value;
+                    status.label = result.value;
                 }, q.object, qname("rdfs:label"), null);
+
+                store.value.forObjects(result => {
+                    status.color = result.value;
+                }, q.object, qname("sdo:color"), null);
+                c.status = status;
             } else if (flavour.value === "VocPrez" && q.predicate.value === qname("prov:qualifiedDerivation")) {
                 store.value.forObjects(result => {
                     c.derivationMode = getIRILocalName(result.value);


### PR DESCRIPTION
This PR updates the vocab listing table.

The reg status column is now a hyperlink to the PID of the reg status concept with a colour indicator.

The derivation mode column is now a hyperlink to the PID of the derivation mode concept.

These changes depend on the backend changes in Prez in https://github.com/RDFLib/prez/pull/117.

Screenshot below with the changes to the listing table's status and derivation mode columns.

![Screenshot 2023-05-29 at 3 31 31 pm](https://github.com/RDFLib/prez-ui/assets/37032744/7a584443-c586-4400-848d-6cd469b9009b)

Note: Ignore the label of the derivation mode, the IRI of the concept returned is wrong in the GSQ data, so it's just showing the local name as a fallback. Data that are using the correct IRIs of the derivation mode will use the labels returned by the API.