### PR TITLE
Fix base URL for Vite assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY package*.json ./
 RUN npm install
 COPY . ./
 RUN rm .env
-RUN CI=false npm run build
+RUN CI=false VITE_DYNAMIC_BASE_URL=1 npm run build
 
 FROM nginx:alpine AS prod
 RUN apk add --no-cache bash

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -17,6 +17,7 @@ done
 if (declare -p "VITE_BASE_URL" &>/dev/null)
 then
     sed -i "s|BASE_URL = \"/\"|BASE_URL = \"$VITE_BASE_URL\"|g" /app/index.html
+    sed -i "s|/@BASE_URL@/|$VITE_BASE_URL|g" /app/index.html ${INDEX_FILE}
     cp /app/index.html /app/404.html
 fi
 

--- a/index.html
+++ b/index.html
@@ -19,35 +19,6 @@
     <script>
         var BASE_URL = "/";
 
-        const files = [
-            "/@vite/client",
-            "/theme/favicon.ico",
-            "/style.css",
-            "/theme/theme.css",
-            "/assets/*.js",
-            "/assets/*.css"
-        ];
-
-        const headScriptElements = document.querySelectorAll("head > script:not(.external)");
-        const headLinkElements = document.querySelectorAll("head > link:not(.external)");
-
-        function modifyPaths(elementArray, attr) {
-            elementArray.forEach(element => {
-                const url = new URL(element[attr]);
-                const file = files.find(f => new RegExp(`.*${f.replace("/", "\/").replace("*", ".*")}$`).test(url.pathname));
-                const baseUrl = url.pathname.replace(new RegExp(`${file.replace("/", "\/").replace("*", ".*")}`), "") + "/";
-                if (BASE_URL === "/" && baseUrl !== "/") { // vite dev server/build -> change BASE_URL
-                    BASE_URL = baseUrl;
-                } else if (BASE_URL !== "/" && baseUrl == "/") { // docker container -> change path prefix
-                    url.pathname = BASE_URL + url.pathname.slice(1);
-                    element[attr] = url.toString();
-                }
-            });
-        }
-
-        modifyPaths(headScriptElements, "src");
-        modifyPaths(headLinkElements, "href");
-        
         fetch(`${BASE_URL}header.html`)
             .then(response => {
                 if (response.ok) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,6 @@ export default defineConfig(({ mode }) => {
                 }
             }
         },
-        base: process.env.GH_PAGES_DEMO ? "/prez-ui/" : (process.env.VITE_BASE_URL || "/"),
+        base: process.env.GH_PAGES_DEMO ? "/prez-ui/" : (process.env.VITE_DYNAMIC_BASE_URL ? '/@BASE_URL@/' : (process.env.VITE_BASE_URL || "/")),
     };
 });


### PR DESCRIPTION
@jamiefeiss, I've updated your proposed changes for the base URL stuff. It should be working now.

Basically, when the `VITE_DYNAMIC_BASE_URL` env variable is set (which it is for docker builds), Vite's base URL will be set to `@BASE_URL@`. Then, on the entrypoint, we replace all occurrences of `/@BASE_URL@/` (in index.html and index.*.js) with the runtime value of `VITE_BASE_URL`. 