### PR TITLE
Fixed profile error on object & listing pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,31 +31,6 @@ const { store: combinedStore, prefixes: combinedPrefixes, parseIntoStore: combin
 document.title = ui.pageTitle;
 
 onMounted(() => {
-    // get API details
-    doRequest(apiBaseUrl, () => {
-        parseIntoStore(data.value);
-
-        // get API version
-        const version = store.value.getObjects(null, qname("prez:version"), null)[0];
-        ui.apiVersion = version.value;
-
-        // get search methods per flavour
-        let searchMethods: {[key: string]: string[]} = {};
-        store.value.forObjects(object => {
-            let flavour = "";
-            let methods: string[] = [];
-            store.value.forEach(q => {
-                if (q.predicate.value === qname("a")) {
-                    flavour = q.object.value.split(`${qname('prez:')}`)[1];
-                } else if (q.predicate.value === qname("prez:availableSearchMethod")) {
-                    methods.push(q.object.value.split(`${qname('prez:')}`)[1]);
-                }
-            }, object, null, null, null);
-            searchMethods[flavour] = methods;
-        }, null, qname("prez:enabledPrezFlavour"), null);
-        ui.searchMethods = searchMethods;
-    });
-
     // if profiles don't exist in pinia
     if (Object.keys(ui.profiles).length === 0) {
         profDoRequest(`${apiBaseUrl}/profiles`, () => {
@@ -123,6 +98,31 @@ onMounted(() => {
             });
         });
     }
+
+    // get API details
+    doRequest(apiBaseUrl, () => {
+        parseIntoStore(data.value);
+
+        // get API version
+        const version = store.value.getObjects(null, qname("prez:version"), null)[0];
+        ui.apiVersion = version.value;
+
+        // get search methods per flavour
+        let searchMethods: {[key: string]: string[]} = {};
+        store.value.forObjects(object => {
+            let flavour = "";
+            let methods: string[] = [];
+            store.value.forEach(q => {
+                if (q.predicate.value === qname("a")) {
+                    flavour = q.object.value.split(`${qname('prez:')}`)[1];
+                } else if (q.predicate.value === qname("prez:availableSearchMethod")) {
+                    methods.push(q.object.value.split(`${qname('prez:')}`)[1]);
+                }
+            }, object, null, null, null);
+            searchMethods[flavour] = methods;
+        }, null, qname("prez:enabledPrezFlavour"), null);
+        ui.searchMethods = searchMethods;
+    });
 });
 </script>
 

--- a/src/components/LoadingMessage.vue
+++ b/src/components/LoadingMessage.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup>
+
+</script>
+
+<template>
+    <div class="loading-message">
+        <div class="message">
+            <i class="fa-regular fa-spinner-third fa-spin"></i>
+            <span>Loading...</span>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/sass/_variables.scss";
+
+.loading-message {
+    border-radius: $borderRadius;
+    background-color: var(--cardBg);
+    padding: 20px;
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+    margin: 0 40px;
+
+    .message {
+        display: flex;
+        flex-direction: row;
+        gap: 12px;
+    }
+}
+</style>

--- a/src/components/navs/MainNav.vue
+++ b/src/components/navs/MainNav.vue
@@ -122,7 +122,7 @@ onUnmounted(() => {
             <div class="nav-item"><RouterLink to="/" class="nav-link">Home</RouterLink></div>
             <template v-for="prez in enabledPrezs">
                 <div class="nav-item" :style="{ position: 'relative' }">
-                    <RouterLink :to="`/${prez.toLowerCase()[0]}`" :class="`nav-link ${!props.sidenav && route.path.startsWith(`/${prez.toLowerCase()[0]}`) ? 'active' : ''}`">
+                    <RouterLink :to="`/${prez.toLowerCase()[0]}`" :class="`nav-link ${!props.sidenav && route.path.startsWith(`/${prez.toLowerCase()[0]}/`) ? 'active' : ''}`">
                         {{ getPrezSystemLabel(prez) }}
                     </RouterLink>
                     <button class="dropdown-btn" @click="clickDropdown(prez)">

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,0 +1,22 @@
+import { useUiStore } from "@/stores/ui";
+
+const ui = useUiStore();
+
+/**
+ * Periodically checks if the profiles object is set in Pinia before resolving a Promise.
+ * 
+ * Loops every 500ms, times out after 20s.
+ */
+export function ensureProfiles() {
+    return new Promise<void>((resolve, reject) => {
+        let expTimer = setTimeout(reject, 20 * 1000); // time out after 20s
+               
+        (function waitForProfiles() {
+            if (Object.keys(ui.profiles).length > 0) {
+                clearTimeout(expTimer);
+                return resolve();
+            };
+            setTimeout(waitForProfiles, 500); // checks every 500ms
+        })();
+    });
+};

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -13,6 +13,7 @@ import ErrorMessage from "@/components/ErrorMessage.vue";
 import PaginationComponent from "@/components/PaginationComponent.vue";
 import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 import SortableTabularList from "@/components/SortableTabularList.vue";
+import LoadingMessage from "@/components/LoadingMessage.vue";
 
 const { namedNode } = DataFactory;
 
@@ -286,28 +287,45 @@ onBeforeMount(() => {
     }
 });
 
+function ensureProfiles() {
+    return new Promise<void>((resolve, reject) => {
+        let expTimer = setTimeout(reject, 10 * 1000); // time out after 10s
+               
+        (function waitForProfiles() {
+            if (Object.keys(ui.profiles).length > 0) {
+                clearTimeout(expTimer)
+                return resolve()
+            };
+            setTimeout(waitForProfiles, 500);
+        })();
+    })
+}
+
 onMounted(() => {
-    doRequest(`${apiBaseUrl}${route.fullPath}`, () => {
-        defaultProfile.value = ui.profiles[profiles.value.find(p => p.default)!.uri];
-        
-        // if specify mediatype, or profile is not default or alt, redirect to API
-        if ((route.query && route.query._profile) &&
-            (route.query._mediatype || ![defaultProfile.value.token, ALT_PROFILES_TOKEN].includes(route.query._profile as string))) {
-                window.location.replace(`${apiBaseUrl}${route.path}?_profile=${route.query._profile}${route.query._mediatype ? `&_mediatype=${route.query._mediatype}` : ""}`);
-        }
+    loading.value = true;
+    ensureProfiles().then(() => {
+        doRequest(`${apiBaseUrl}${route.fullPath}`, () => {
+            defaultProfile.value = ui.profiles[profiles.value.find(p => p.default)!.uri];
+            
+            // if specify mediatype, or profile is not default or alt, redirect to API
+            if ((route.query && route.query._profile) &&
+                (route.query._mediatype || ![defaultProfile.value.token, ALT_PROFILES_TOKEN].includes(route.query._profile as string))) {
+                    window.location.replace(`${apiBaseUrl}${route.path}?_profile=${route.query._profile}${route.query._mediatype ? `&_mediatype=${route.query._mediatype}` : ""}`);
+            }
 
-        // disable right nav if AltView
-        if (isAltView.value) {
-            ui.rightNavConfig = { enabled: false };
-        } else {
-            ui.rightNavConfig = { enabled: true, profiles: profiles.value, currentUrl: route.path };
-        }
+            // disable right nav if AltView
+            if (isAltView.value) {
+                ui.rightNavConfig = { enabled: false };
+            } else {
+                ui.rightNavConfig = { enabled: true, profiles: profiles.value, currentUrl: route.path };
+            }
 
-        parseIntoStore(data.value);
-        getProperties();
+            parseIntoStore(data.value);
+            getProperties();
 
-        document.title = `${itemType.value.label} | Prez`;
-        ui.breadcrumbs = getBreadcrumbs();
+            document.title = `${itemType.value.label} | Prez`;
+            ui.breadcrumbs = getBreadcrumbs();
+        });
     });
 });
 </script>
@@ -317,13 +335,9 @@ onMounted(() => {
     <template v-else>
         <h1 class="page-title">{{ itemType.label }}</h1>
         <p>A list of <a :href="itemType.uri" target="_blank" rel="noopener noreferrer">{{ itemType.label }}.</a></p>
-        <p v-if="items.length > 0">Showing {{ items.length }} of {{ count }} items.</p>
-        <template v-if="error">
-            <ErrorMessage :message="error" />
-        </template>
-        <template v-else-if="loading">
-            <i class="fa-regular fa-spinner-third fa-spin"></i> Loading...
-        </template>
+        <p v-if="!loading && items.length > 0">Showing {{ items.length }} of {{ count }} items.</p>
+        <ErrorMessage v-if="error" :message="error" />
+        <LoadingMessage v-else-if="loading" />
         <template v-else-if="items.length > 0">
             <SortableTabularList v-if="flavour === 'VocPrez'" :items="items" :predicates="['description', 'status', 'derivationMode']" />
             <ItemList v-else :items="items" :childName="childrenConfig.buttonTitle" :childLink="childrenConfig.buttonLink" />

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -14,6 +14,7 @@ import PaginationComponent from "@/components/PaginationComponent.vue";
 import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 import SortableTabularList from "@/components/SortableTabularList.vue";
 import LoadingMessage from "@/components/LoadingMessage.vue";
+import { ensureProfiles } from "@/util/helpers";
 
 const { namedNode } = DataFactory;
 
@@ -286,20 +287,6 @@ onBeforeMount(() => {
         isAltView.value = true;
     }
 });
-
-function ensureProfiles() {
-    return new Promise<void>((resolve, reject) => {
-        let expTimer = setTimeout(reject, 10 * 1000); // time out after 10s
-               
-        (function waitForProfiles() {
-            if (Object.keys(ui.profiles).length > 0) {
-                clearTimeout(expTimer)
-                return resolve()
-            };
-            setTimeout(waitForProfiles, 500);
-        })();
-    })
-}
 
 onMounted(() => {
     loading.value = true;

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -16,6 +16,7 @@ import MapClient from "@/components/MapClient.vue";
 import type { WKTResult } from "@/stores/mapSearchStore.d";
 import SortableTabularList from "@/components/SortableTabularList.vue";
 import LoadingMessage from "@/components/LoadingMessage.vue";
+import { ensureProfiles } from "@/util/helpers";
 
 const { namedNode } = DataFactory;
 
@@ -441,20 +442,6 @@ onBeforeMount(() => {
         isAltView.value = true;
     }
 });
-
-function ensureProfiles() {
-    return new Promise<void>((resolve, reject) => {
-        let expTimer = setTimeout(reject, 10 * 1000); // time out after 10s
-               
-        (function waitForProfiles() {
-            if (Object.keys(ui.profiles).length > 0) {
-                clearTimeout(expTimer)
-                return resolve()
-            };
-            setTimeout(waitForProfiles, 500);
-        })();
-    })
-}
 
 onMounted(() => {
     loading.value = true;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -95,9 +95,7 @@ onMounted(() => {
 <template>
     <h1 class="page-title">Advanced Search</h1>
     <AdvancedSearch :query="query" fullPage/>
-    <template v-if="error">
-        <ErrorMessage :message="error" />
-    </template>
+    <ErrorMessage v-if="error" :message="error" />
     <template v-else-if="loading">
         <h3>Loading...</h3>
         <span class="loading-icon"></span>


### PR DESCRIPTION
Addressed an error on object & listing pages opened in a new tab caused by a race condition on retrieving profiles & saving in the Pinia store. Added a guard (a retry loop with a timeout of 10s) to requests on those pages to ensure that the profiles have been loaded in Pinia before firing off those requests. Resolves #66.

Also added a loading spinner component to those pages, as well as a small fix to the navbar.