### PR TITLE
Restyled catalog & spatial search

### DIFF
--- a/src/assets/sass/main.scss
+++ b/src/assets/sass/main.scss
@@ -69,7 +69,7 @@ a {
     border-radius: $borderRadius;
     @include transition(color, background-color);
 
-    &:hover {
+    &:hover:not(:disabled) {
         background-color: var(--primaryBtnHover);
     }
 
@@ -77,7 +77,7 @@ a {
         background-color: transparent;
         color: var(--primary);
 
-        &:hover {
+        &:hover:not(:disabled) {
             background-color: var(--primary);
             color: white;
         }
@@ -86,6 +86,11 @@ a {
     &.sm {
         font-size: 0.7em;
         padding: 4px 6px;
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.6;
     }
 }
 

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,0 +1,126 @@
+<script lang="ts" setup>
+import { onMounted, onUnmounted, useSlots } from "vue";
+
+const emit = defineEmits(["modalClosed"]);
+
+const slots = useSlots();
+
+const onEscape = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+        emit("modalClosed");
+    }
+}
+
+onMounted(() => {
+    window.addEventListener("keyup", onEscape);
+});
+
+onUnmounted(() => {
+    window.removeEventListener("keyup", onEscape);
+});
+</script>
+
+<template>
+    <div class="modal" @click.self="emit('modalClosed')">
+        <div class="modal-content">
+            <div class="modal-header">
+                <div class="modal-header-third">
+                    <slot name="headerLeft"></slot>
+                </div>
+                <div class="modal-header-third middle">
+                    <slot name="headerMiddle"></slot>
+                </div>
+                <div class="modal-header-third">
+                    <slot name="headerRight"></slot>
+                    <span @click="emit('modalClosed')" class="modal-close" title="Close"><i class="fa-light fa-xmark"></i></span>
+                </div>
+            </div>
+            <div class="modal-body">
+                <slot></slot>
+            </div>
+            <div class="modal-footer" v-if="!!slots.footer">
+                <slot name="footer"></slot>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped lang="scss">
+@import "@/assets/sass/_variables.scss";
+
+.modal {
+    position: fixed;
+    z-index: 9999;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background-color: rgba(0, 0, 0, 0.4);
+
+    .modal-content {
+        background-color: white;
+        margin: 10rem auto;
+        width: 60%;
+        display: flex;
+        flex-direction: column;
+        border-radius: $borderRadius;
+        max-height: 70%;
+
+        .modal-header {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            padding: 8px;
+            gap: 8px;
+
+            .modal-header-third {
+                display: flex;
+                flex-direction: row;
+                gap: 8px;
+                align-items: center;
+                
+                &:not(.middle) {
+                    flex-basis: 0;
+                    flex-grow: 1;
+                }
+
+                :deep(h1), :deep(h2), :deep(h3), :deep(h4), :deep(h5), :deep(h6) {
+                    margin-top: 0;
+                    margin-bottom: 0;
+                }
+            }
+
+            .modal-close {
+                padding: 8px;
+                color: #929292;
+                cursor: pointer;
+                margin-left: auto;
+
+                &:hover {
+                    color: #afafaf;
+                }
+            }
+        }
+
+        .modal-body {
+            $borderColor: #c9c9c9;
+            display: flex;
+            flex-direction: column;
+            padding: 8px;
+            gap: 8px;
+            overflow-y: auto;
+            border-top: 1px solid $borderColor;
+            border-bottom: 1px solid $borderColor;
+        }
+
+        .modal-footer {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px;
+        }
+    }
+}
+</style>

--- a/src/components/ButtonGroup.vue
+++ b/src/components/ButtonGroup.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="button-container">
-    <div v-for="(button, index) in buttons" :key="index" @click="selectButton(index)" class="btn sm" :class="{ outline: !selectedButtons.includes(index) }">
+    <button v-for="(button, index) in buttons" :key="index" @click="selectButton(index)" class="btn sm" :class="{ outline: !selectedButtons.includes(index) }" :disabled="props.disabled">
       {{ button.text }}
-    </div>
+    </button>
   </div>
 </template>
 
@@ -26,7 +26,11 @@ const props = defineProps({
   initialValue: {
     type: String,
     default: null
-  }
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  },
 })
 
 const selectedButtons = ref<number[]>([])

--- a/src/components/MapClient.vue
+++ b/src/components/MapClient.vue
@@ -1,9 +1,8 @@
 <script lang="ts" setup>
-
 /// <reference path="../../node_modules/@types/google.maps/index.d.ts" /> 
 
-import { wktToGeoJSON } from "@terraformer/wkt"
 import { inject, reactive, ref, watch, type PropType } from 'vue'
+import { wktToGeoJSON } from "@terraformer/wkt"
 import { mapConfigKey, type MapConfig } from "@/types";
 import { convertConfigTypes } from '@/util/mapSearchHelper'
 import type { MapOptionsCenter } from '@/types'
@@ -33,7 +32,7 @@ const props = defineProps({
     style: {
         type: String,
         default: 'width: 100%; height: 500px; background-color: #eee;'
-    }    
+    }
 })
 
 // when the map object has loaded, it will call this function to set mapDrawFunc, so an external component can call it when needed
@@ -237,5 +236,4 @@ watch(mapRef, googleMap => {
         :style="props.style" 
     >
     </GMapMap>
-
 </template>

--- a/src/components/search/CatPrezSearchMap.vue
+++ b/src/components/search/CatPrezSearchMap.vue
@@ -1,27 +1,82 @@
 <script lang="ts" setup>
+import { onMounted, ref, computed } from "vue";
+
 // the searchable map component and related map type definitions
 import MapClient from "@/components/MapClient.vue";
 import { AreaTypes, ShapeTypes, type Coords } from "@/components/MapClient.d";
 
-// the pinia search store and related type definitions to manage the returned dataset tree
+// the pinia search store and related type definitions to manage the returned catalog tree
 import { refDataStore } from "@/stores/refDataStore";
-import { onMounted, ref } from "vue";
-import { QUERY_GET_CATALOGS, QUERY_GET_THEMES, QUERY_SEARCH } from '@/stores/catalogQueries'
-import type { RDCatalog, RDSearch, RDTheme } from '@/stores/catalogQueries.d'
-import { shapeQueryPart } from '@/util/mapSearchHelper'
+import { QUERY_GET_CATALOGS, QUERY_GET_THEMES, QUERY_SEARCH } from "@/stores/catalogQueries"
+import type { RDCatalog, RDSearch, RDTheme } from "@/stores/catalogQueries.d"
+import { shapeQueryPart } from "@/util/mapSearchHelper"
 
-const rdCatalogs = refDataStore('catalogs')()
-const rdThemes = refDataStore('themes')()
-const rdSearch = refDataStore('search')()
+import LoadingMessage from "@/components/LoadingMessage.vue";
+import ErrorMessage from "@/components/ErrorMessage.vue";
+import BaseModal from "@/components/BaseModal.vue";
 
-const searchTermRef = ref('')
+const MAX_DESC_LENGTH = 200;
+
+const rdCatalogs = refDataStore("catalogs")()
+const rdThemes = refDataStore("themes")()
+const rdSearch = refDataStore("search")()
+
+const searchTermRef = ref("")
 const selectedCatalogsRef = ref<string[]>([])
 const selectedThemesRef = ref<string[]>([])
 const shapeTypeRef = ref(ShapeTypes.None)
 const coordsRef = ref<Coords>([])
 const showQueryRef = ref(false)
-const sparqlQueryRef = ref('')
+const sparqlQueryRef = ref("")
 const limitRef = ref(10)
+
+const modal = ref<string | null>(null);
+
+const allCatalogsSelected = computed(() => {
+    let allSelected = true;
+    (rdCatalogs.data as RDCatalog[]).forEach(catalog => {
+        if (!selectedCatalogsRef.value.includes(catalog.c)) {
+            allSelected = false;
+            return false;
+        }
+    });
+    return allSelected;
+});
+
+const allThemesSelected = computed(() => {
+    let allSelected = true;
+    (rdThemes.data as RDTheme[]).forEach(theme => {
+        if (!selectedThemesRef.value.includes(theme.th)) {
+            allSelected = false;
+            return false;
+        }
+    });
+    return allSelected;
+});
+
+async function toggleSelectAllCatalogs() {
+    let selectedCatalogs: string[] = [];
+    if (!allCatalogsSelected.value) {
+        (rdCatalogs.data as RDCatalog[]).forEach(catalog => {
+            selectedCatalogs.push(catalog.c);
+        });
+    }
+    selectedCatalogsRef.value = selectedCatalogs;
+
+    await performSearch();
+}
+
+async function toggleSelectAllThemes() {
+    let selectedThemes: string[] = [];
+    if (!allThemesSelected.value) {
+        (rdThemes.data as RDTheme[]).forEach(theme => {
+            selectedThemes.push(theme.th);
+        });
+    }
+    selectedThemesRef.value = selectedThemes;
+
+    await performSearch();
+}
 
 // called when a selection has changed
 const updateSelection = async (selectedCoords:Coords, shapeType:ShapeTypes) => {
@@ -40,7 +95,7 @@ const links = [
 ];
 
 const fetchThemes = async () => {
-    await rdThemes.fetch<RDTheme[]>('c', QUERY_GET_THEMES(selectedCatalogsRef.value));
+    await rdThemes.fetch<RDTheme[]>("c", QUERY_GET_THEMES(selectedCatalogsRef.value));
 }
 
 const performSearch = async(event: Event|null=null) => {
@@ -49,12 +104,16 @@ const performSearch = async(event: Event|null=null) => {
     }
     sparqlQueryRef.value = QUERY_SEARCH(selectedCatalogsRef.value, searchTermRef.value, selectedThemesRef.value, shapeQueryPart(coordsRef.value), //limitRef.value);
         (limitRef.value > 0 ? parseInt(limitRef.value.toString()) + 1 : 0));
-    await rdSearch.fetch<RDSearch[]>('c', sparqlQueryRef.value)
+    await rdSearch.fetch<RDSearch[]>("c", sparqlQueryRef.value)
+}
+
+function copySPARQL() {
+    navigator.clipboard.writeText(sparqlQueryRef.value);
 }
 
 // start off by loading the main filter lists for catalogs and themes
 onMounted(async ()=>{
-    await rdCatalogs.fetch<RDCatalog[]>('c', QUERY_GET_CATALOGS);
+    await rdCatalogs.fetch<RDCatalog[]>("c", QUERY_GET_CATALOGS);
     (rdCatalogs.data as RDCatalog[]).forEach(cat=>{
         selectedCatalogsRef.value.push(cat.c)
     });
@@ -68,277 +127,270 @@ onMounted(async ()=>{
 </script>
 
 <template>
-    <div class="container">
-        <div class="left-panel">
-            <form @submit="(event)=>performSearch(event)" class="query-options">
-                <div class="query-option">
-                    <h4 class="query-option-title">Catalogues to include</h4>
-                    <ul>
-                        <li v-for="cat in <RDCatalog[]>rdCatalogs.data" :key="cat.c">
-                            <label>
-                                <input type="checkbox" 
-                                    :value="cat.c" 
-                                    v-model="selectedCatalogsRef" 
-                                    @change="async (event) => { await fetchThemes(); await performSearch(); }"
-                                /> {{ cat.t }}
-                            </label>
-                        </li>
-                    </ul>
-
-                    <h4 class="query-option-title">Search text</h4>
-                    <p>
+    <div class="catalog-search">
+        <div class="search-options">
+            <div class="search-form-container">
+                <div class="search-form">
+                    <div class="form-section">
+                        <h4>Text Search</h4>
                         <input
                             type="search"
                             name="term"
                             class="search-input"
                             v-model="searchTermRef"
-                            placeholder="enter search terms"
+                            placeholder="Search..."
+                            @keyup.enter="performSearch()"
                         >
-                    </p>
-
-                    <h4 class="query-option-title">Theme filter</h4>
-                    <ul>
-                        <li v-for="theme in <RDTheme[]>rdThemes.data" :key="theme.th">
-                            <label>
+                    </div>
+                    <div class="form-section">
+                        <h4>Catalogues</h4>
+                        <div class="catalog-buttons">
+                            <div class="select-all-input">
+                                <input type="checkbox" name="select-all-catalogs" id="select-all-catalogs" @change="toggleSelectAllCatalogs" v-model="allCatalogsSelected">
+                                <label for="select-all-catalogs">Select all</label>
+                            </div>
+                        </div>
+                        <LoadingMessage v-if="rdCatalogs.loading" />
+                        <ErrorMessage v-else-if="rdCatalogs.error" :message="`Unable to load catalogs: ${rdCatalogs.error}`" />
+                        <ul v-else-if="rdCatalogs.data.length > 0" class="catalog-options">
+                            <li v-for="(catalog, index) in <RDCatalog[]>rdCatalogs.data" class="catalog-option" :style="catalog.c.endsWith('/system/catprez') ? 'display: none;' : ''">
+                                <input type="checkbox" :id="`catalog-${index}`" :value="catalog.c" v-model="selectedCatalogsRef" @change="async (event) => { await fetchThemes(); await performSearch(); }" />
+                                <label :for="`catalog-${index}`">{{ catalog.t }}</label>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="form-section">
+                        <h4>Themes</h4>
+                        <div class="theme-buttons">
+                            <div class="select-all-input">
+                                <input type="checkbox" name="select-all-themes" id="select-all-themes" @change="toggleSelectAllThemes" v-model="allThemesSelected">
+                                <label for="select-all-themes">Select all</label>
+                            </div>
+                        </div>
+                        <LoadingMessage v-if="rdThemes.loading" />
+                        <ErrorMessage v-else-if="rdThemes.error" :message="`Unable to load catalogs: ${rdThemes.error}`" />
+                        <ul v-else-if="rdThemes.data.length > 0" class="theme-options">
+                            <li v-for="(theme, index) in <RDTheme[]>rdThemes.data" class="theme-option" :key="theme.th">
                                 <input type="checkbox" 
                                     :value="theme.th" 
-                                    v-model="selectedThemesRef" 
+                                    v-model="selectedThemesRef"
+                                    :id="`theme-${index}`"
                                     @change="(event) => performSearch()"
-                                /> {{ theme.pl }}
-                            </label>
-                        </li>
-                        <li v-if="rdThemes.data.length == 0">(none)</li>
-                    </ul>
+                                />
+                                <label :for="`theme-${index}`">{{ theme.pl }}</label>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-
-                <div class="btn-container">
-                    <span class="nowrap">Results limit: <input id="input-limit" class="space-right" v-model="limitRef" /></span>
-                    <span class="nowrap"><label class="space-right"><input v-model="showQueryRef" type="checkbox">Show query</label></span>
-                    <button class="btn" type="submit">Search</button>
+                <div class="bottom-buttons">
+                    <button class="btn outline" @click="modal = 'sparqlQuery'">Show Query <i class="fa-regular fa-code"></i></button>
+                    <div class="right-buttons">
+                        <div class="result-limit-input">
+                            <label for="result-limit">Result limit</label>
+                            <input id="result-limit" type="number" @change="performSearch()" v-model="limitRef" min="1" max="100">
+                        </div>
+                        <button class="btn" @click="performSearch()">Search <i class="fa-regular fa-magnifying-glass"></i></button>
+                    </div>
                 </div>
-
-            </form>
+            </div>
+            <div class="search-map">
+                <MapClient
+                    ref="searchMapRef"
+                    :drawing-modes="['RECTANGLE']"
+                    @selectionUpdated="updateSelection"
+                />
+            </div>
         </div>
-        <div class="right-panel">
-            <MapClient 
-                ref="searchMapRef" 
-                :drawing-modes="['RECTANGLE']"
-                @selectionUpdated="updateSelection"
-                :style="'width: 100%; height: 550px; background-color: #eee;'"
-            />
-        </div>
-
-    </div>
-
-    <div v-if="rdSearch.loading">
-        <h3>Loading...</h3>
-        <div class="loading-icon"></div>
-    </div>
-    <div v-else>
-        <div v-if="rdSearch.data && rdSearch.data.length > 0">
-            <h3>Result set ({{ limitRef == 0 ? `${limitRef}` : rdSearch.data.length > limitRef ? `${limitRef}+` : rdSearch.data.length }})</h3>
-            <table>
+        <div class="results">
+            <h3>Results</h3>
+            <LoadingMessage v-if="rdSearch.loading" />
+            <ErrorMessage v-else-if="rdSearch.error" :message="rdSearch.error" />
+            <table v-else-if="rdSearch.data && rdSearch.data.length > 0">
                 <thead>
-                    <th>Resource Label</th>
-                    <th>Resource Description</th>
-                    <th>Theme Labels</th>
+                    <tr>
+                        <th>Title</th>
+                        <th>Themes</th>
+                    </tr>
                 </thead>
                 <tbody>
                     <template v-for="(result, index) in <RDSearch[]>rdSearch.data">
-                        <tr :key="index" v-if="limitRef === 0 || index < limitRef">                            
-                            <td><a target="_blank" v-bind:href="`/object?uri=${result.r}`">{{ result.t }}</a></td>
-                            <td>{{ result.d }}</td>
-                            <td class="th-list"><a v-for="(th, tindex) in result.thlist.split('\t')" target="_blank" v-bind:href="`/object?uri=${th}`">{{ result.thpllist.split('\t')[tindex] }}</a></td>
+                        <tr :class="`${index % 2 === 1 ? 'grey' : '' }`">
+                            <td><a :href="`/object?uri=${encodeURIComponent(result.r)}`">{{ result.t }}</a></td>
+                            <td>
+                                <template v-for="(th, tindex) in result.thlist.split('\t')">
+                                    <a :href="`/object?uri=${th}`">
+                                        {{ result.thpllist.split('\t')[tindex] }}
+                                    </a>
+                                    <br/>
+                                </template>
+                            </td>
+                        </tr>
+                        <tr v-if="result.d" :class="`${index % 2 === 1 ? 'grey' : '' }`">
+                            <td colspan="2" class="desc">{{ result.d.length > MAX_DESC_LENGTH ? result.d.slice(0, MAX_DESC_LENGTH) + '...' : result.d }}</td>
                         </tr>
                     </template>
                 </tbody>
             </table>
-        </div>
-        <div v-else-if="rdSearch.error">
-            <h3>Unable to search map</h3>
-            <div class="error">
-                {{ rdSearch.error }}
+            <div v-else>
+                No results
             </div>
         </div>
-        <div v-else>
-            <h3>No results</h3>
-        </div>
     </div>
-
-
-<pre v-if="showQueryRef" class="debug">
-
-<b>SPARQL query:</b>
-
-{{ sparqlQueryRef }}
-
-</pre>
-
-
+    <BaseModal v-if="modal === 'sparqlQuery'" @modalClosed="modal = null">
+        <template #headerMiddle>Spatial Search SPARQL Query</template>
+        <div class="sparql-query-content">
+            <pre>{{ sparqlQueryRef.trim() }}</pre>
+        </div>
+        <template #footer>
+            <button class="btn outline sparql-copy-btn" @click="copySPARQL" title="Copy SPARQL query">Copy <i class="fa-regular fa-copy"></i></button>
+        </template>
+    </BaseModal>
 </template>
 
 <style lang="scss" scoped>
 @import "@/assets/sass/_variables.scss";
 
-.btn-container {
-    margin-top: auto;
-    text-align:right;
-}
-
-.th-list a {
-    display:block;
-}
-
-table {
-    border-collapse: collapse;
-    background-color: white;
-    width:100%;
-    thead {
-        th {
-            padding: 10px;
-            background-color: #ccc;
-            text-align:left;
-        }
-    }
-    tbody {
-        td {
-            padding: 5px;
-        }
-    }
-    tr {
-        th, td {
-        }
-
-        th {
-            text-align: center;
-        }
-
-        &:nth-child(2n) {
-            background-color: var(--tableBg);
-        }
-    }
-}
-
-
-.container {
-    display: grid;
-    grid-template-columns: 1fr 3fr; /* set the column widths to 1/4 and 3/4 of the container width */
-}
-
-.left-panel {
-    min-width: 480px;
-    padding-right: 1em;
-}
-.right-panel {
-}
-
-.search-input {
-    width: 100%;
-}
-
-
-/* Media query for small screens */
-@media (max-width: 1024px) {
-    .container {
-        grid-template-columns: 1fr;
-    }
-    .left-panel {
-        margin-bottom: 2em;
-        width: 100%;
-        padding-right: 0;
-    }
-    .search-input {
-        width:100%;
-    }
-}
-
-.space-right {
-    margin-right:1em;    
-}
-
-#input-limit {
-    width:3em;
-}
-
-.msg {
-    color: var(--primary);    
-}
-
-.nowrap {
-    display:inline-block;
-    white-space: nowrap;
-    margin-top:10px;
-}
-
-ul li {
-    list-style-type: none;
-    padding-bottom: 4px;
-}
-
-ul {
-    padding-left:0;
-    margin-left:0;
-}
-
-pre.debug {
-    white-space: break-spaces;
-}
-
-.small-input {
-    font-size:small;
-    height:1.5em;
-    width:3em; 
-}
-.query-options {
+.catalog-search {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    background-color: var(--cardBg);
-    padding: 10px;
-    border-radius: $borderRadius;
-    min-height: 550px;
+    gap: 20px;
 
-    .query-option {
+    .search-options {
+        display: grid;
+        grid-template-columns: 2fr 3fr;
+        // gap: 20px;
 
-        padding-bottom: 20px;
+        .search-form-container {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding: 12px;
+            background-color: var(--cardBg);
+            border-radius: $borderRadius;
+            height: 500px;
 
-        .query-option-title {
-            padding-top:0;
-            margin-top:5px;
-            margin-bottom:8px;
+            .search-form {
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+                flex-grow: 1;
+                overflow-y: auto;
+
+                .form-section {
+                    display: flex;
+                    flex-direction: column;
+
+                    h4 {
+                        margin: 0px 0px 10px 0px;
+                    }
+
+                    // .search-input {
+                    //     width: 100%;
+                    // }
+
+                    .catalog-buttons, .theme-buttons {
+                        display: flex;
+                        flex-direction: row;
+                        gap: 8px;
+                        align-items: center;
+                        margin-bottom: 12px;
+                    }
+
+                    ul.catalog-options, ul.theme-options {
+                        padding-left: 0;
+                        margin: 0;
+                        
+                        li.catalog-option, li.theme-option {
+                            list-style-type: none;
+                            margin-bottom: 6px;
+                        }
+                    }
+                }
+            }
+
+            .bottom-buttons {
+                display: flex;
+                flex-direction: row;
+                gap: 8px;
+                justify-content: space-between;
+                align-items: center;
+
+                .right-buttons {
+                    display: flex;
+                    flex-direction: row;
+                    gap: 8px;
+                    align-items: center;
+
+                    .result-limit-input {
+                        display: flex;
+                        flex-direction: row;
+                        gap: 4px;
+                        align-items: center;
+
+                        input {
+                            width: 60px;
+                            padding: 6px;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    .results {
+        h3 {
+            margin-top: 0;
         }
 
-        .button {
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            // table-layout: fixed;
 
+            thead {
+                th {
+                    padding: 10px;
+                    background-color: #ccc;
+                    text-align: center;
+                }
+            }
+
+            tbody {
+                td {
+                    padding: 5px;
+                }
+            }
+
+            tr.grey {
+                background-color: var(--tableBg);
+            }
+
+            .desc {
+                font-size: 0.8em;
+                padding: 0px 8px 8px 8px;
+                color: grey;
+                font-style: italic;
+            }
         }
-
     }
 }
 
-.error {
-    background-color: lightcoral;
-    display: inline-block;
+.sparql-query-content {
+    padding: 12px;
+
+    pre {
+        white-space: pre-wrap;
+        margin: 0;
+    }
 }
 
-.loading-icon {
-  position: relative;
-  width: 20px;
-  height: 20px; 
-  margin:0;
-  padding:0;
-  -webkit-animation: fa-spin 2s infinite linear;
-  animation: fa-spin 2s infinite linear;
+.sparql-copy-btn {
+    margin-left: auto;
 }
 
-.loading-icon:before {
-  content: "\f1ce";
-  font-family: FontAwesome;
-  font-size:20px;
-  line-height:21px;
-  position: absolute;
-  top: 0; 
-  bottom:0;
+@media (max-width: 1024px) {
+    .search-options {
+        grid-template-columns: 1fr !important;
+    }
 }
-
-
 </style>

--- a/src/components/search/SpacePrezSearchMap.vue
+++ b/src/components/search/SpacePrezSearchMap.vue
@@ -231,7 +231,7 @@ const toggleAllFeatures = async (datasetNode: DatasetTreeNode, checked: boolean)
                         <ErrorMessage v-else-if="datasets.error" :message="`Unable to load datasets: ${datasets.error}`" />
                         <ul v-else class="dataset-options">
                             <li v-for="(dataset, dIndex) in datasetTreeRef" class="dataset-option">
-                                <input type="checkbox" :id="`dataset-${dIndex}`" :value="dataset.item.subject" v-model="selectedDatasetsRef" @change="(event: InputEvent) => toggleAllFeatures(dataset, (event.target as HTMLInputElement)?.checked)" />
+                                <input type="checkbox" :id="`dataset-${dIndex}`" :value="dataset.item.subject" v-model="selectedDatasetsRef" @change="toggleAllFeatures(dataset, ($event.target as HTMLInputElement)?.checked)" />
                                 <label :for="`dataset-${dIndex}`">{{ dataset.item.object }}</label>
                                 <button
                                     class="btn outline sm dataset-collapse-btn"

--- a/src/stores/mapSearchStore.ts
+++ b/src/stores/mapSearchStore.ts
@@ -29,7 +29,7 @@ export const mapSearchStore = defineStore({
       data: <WKTResult[]>[],
       success: false,
       loading: false,
-      error: null,
+      error: null as null | string,
       apiBaseUrl: apiBaseUrl
     }
   },
@@ -65,7 +65,7 @@ export const mapSearchStore = defineStore({
 
         } catch (error:any) {
           // set the error status
-          this.error = error.message
+          this.error = error.message as string
           this.data = []
           this.success = false
 

--- a/src/util/mapSearchHelper.ts
+++ b/src/util/mapSearchHelper.ts
@@ -62,7 +62,7 @@ const featureCollectionQueryPart = (featureCollection:string, config: MapSearchC
 
 /** Constructs a SPARQL query for the SpacePrez map search */
 const mapSearchQuery = (featureCollectionsQueryPart:string, topoQueryPart:string, limit:number, config: MapSearchConfig) => `${mapSearchPrefixPart}
-SELECT ?f_uri ?wkt ?fc ?fc_label ?f_label
+SELECT ?f_uri ?wkt ?fc_label ?f_label
 WHERE {
     { ?f_uri geo:hasGeometry/geo:asWKT ?wkt;
     }

--- a/src/util/mapSearchHelper.ts
+++ b/src/util/mapSearchHelper.ts
@@ -55,13 +55,14 @@ PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX prez: <https://prez.dev/>
 `
 
-const featureCollectionQueryPart = (featureCollection:string, config: MapSearchConfig) => ` <${featureCollection}> <${config.spatial.membershipRelationship}> ?f_uri . 
+// need to also select the feature collection URI to generate a link for it in the results
+const featureCollectionQueryPart = (featureCollection:string, config: MapSearchConfig) => `<${featureCollection}> <${config.spatial.membershipRelationship}> ?f_uri . 
 <${featureCollection}> <${config.props.fcLabel}> ?fc_label
 `
 
 /** Constructs a SPARQL query for the SpacePrez map search */
 const mapSearchQuery = (featureCollectionsQueryPart:string, topoQueryPart:string, limit:number, config: MapSearchConfig) => `${mapSearchPrefixPart}
-SELECT ?f_uri ?wkt ?fc_label ?f_label
+SELECT ?f_uri ?wkt ?fc ?fc_label ?f_label
 WHERE {
     { ?f_uri geo:hasGeometry/geo:asWKT ?wkt;
     }

--- a/src/views/catprez/CatPrezHomeView.vue
+++ b/src/views/catprez/CatPrezHomeView.vue
@@ -1,20 +1,21 @@
 <script lang="ts" setup>
-//import FlavourHome from "@/components/FlavourHome.vue";
+import { onMounted } from "vue";
+import { useUiStore } from "@/stores/ui";
 import CatPrezSearchMap from '@/components/search/CatPrezSearchMap.vue'
+import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 
-const links = [
-    {
-        label: "Catalogs",
-        url: "/c/catalogs",
-        description: "A list of DCAT Catalogs"
-    }
-];
+const ui = useUiStore();
 
+onMounted(() => {
+    ui.rightNavConfig = { enabled: false };
+    document.title = "Data Catalog Home | Prez";
+    ui.pageHeading = { name: "CatPrez", url: "/c"};
+    ui.breadcrumbs = [{ name: getPrezSystemLabel("CatPrez") + " Home", url: "/c" }];
+});
 </script>
 
 <template>
-
-    <h1>Data Catalog</h1>
+    <h1 class="page-title">Data Catalog</h1>
     <p>
         A general data catalog conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a>, delivered 
         as a read-only web system in both human and machine-readable views.

--- a/src/views/spaceprez/SpacePrezHomeView.vue
+++ b/src/views/spaceprez/SpacePrezHomeView.vue
@@ -15,7 +15,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <h1>Spatial Data Catalog</h1>
+    <h1 class="page-title">Spatial Data Catalog</h1>
     <p>
         A spatial catalog of Feature Collections and Features conforming to <a href="https://www.w3.org/TR/vocab-dcat-2/">DCAT</a> and 
         <a href="https://www.ogc.org/standard/geosparql/">GeoSPARQL</a>, and delivered as a read-only web system in both human and machine-readable views.


### PR DESCRIPTION
Updated the styling for both spatial search pages to be more consistently laid out.

For both pages, added a "Select all" checkbox for checkbox inputs. For datasets, added a collapse button to collapse contained feature collection checkboxes.

Errors & loading messages now use the shared ErrorMessage & LoadingMessage components on both pages.

Added a modal for viewing the underlying SPARQL query with a copy button.

See screenshots below.
<img width="1260" alt="image" src="https://github.com/RDFLib/prez-ui/assets/58060490/35f61859-3243-4d79-a066-585dff1eb108">
<img width="1258" alt="image" src="https://github.com/RDFLib/prez-ui/assets/58060490/0d62e144-337f-46da-b421-7954219b4132">
<img width="1508" alt="image" src="https://github.com/RDFLib/prez-ui/assets/58060490/93b1ed7a-d257-4329-8fe3-f75ecf8389c3">
