### PR TITLE
Updated SPARQL list queries in spatial search to use single SPARQL Prez endpoint

### DIFF
--- a/src/components/search/CatPrezSearchMap.vue
+++ b/src/components/search/CatPrezSearchMap.vue
@@ -95,7 +95,7 @@ const links = [
 ];
 
 const fetchThemes = async () => {
-    await rdThemes.fetch<RDTheme[]>("c", QUERY_GET_THEMES(selectedCatalogsRef.value));
+    await rdThemes.fetch<RDTheme[]>(QUERY_GET_THEMES(selectedCatalogsRef.value));
 }
 
 const performSearch = async(event: Event|null=null) => {
@@ -104,7 +104,7 @@ const performSearch = async(event: Event|null=null) => {
     }
     sparqlQueryRef.value = QUERY_SEARCH(selectedCatalogsRef.value, searchTermRef.value, selectedThemesRef.value, shapeQueryPart(coordsRef.value), //limitRef.value);
         (limitRef.value > 0 ? parseInt(limitRef.value.toString()) + 1 : 0));
-    await rdSearch.fetch<RDSearch[]>("c", sparqlQueryRef.value)
+    await rdSearch.fetch<RDSearch[]>(sparqlQueryRef.value)
 }
 
 function copySPARQL() {
@@ -113,7 +113,7 @@ function copySPARQL() {
 
 // start off by loading the main filter lists for catalogs and themes
 onMounted(async ()=>{
-    await rdCatalogs.fetch<RDCatalog[]>("c", QUERY_GET_CATALOGS);
+    await rdCatalogs.fetch<RDCatalog[]>(QUERY_GET_CATALOGS);
     (rdCatalogs.data as RDCatalog[]).forEach(cat=>{
         selectedCatalogsRef.value.push(cat.c)
     });

--- a/src/stores/datasetsStore.ts
+++ b/src/stores/datasetsStore.ts
@@ -158,7 +158,7 @@ export const datasetsStore = defineStore({
      * Calls the spacePrez search endpoint using the query for spacePrez
      */
     async fetchSpacePrezData() {
-        return await this.fetchData(`${this.apiBaseUrl}/s/sparql`, getDatasetFeatureQuery(this.mapConfig.search));
+        return await this.fetchData(`${this.apiBaseUrl}/sparql`, getDatasetFeatureQuery(this.mapConfig.search));
     },
 
     /**

--- a/src/stores/mapSearchStore.ts
+++ b/src/stores/mapSearchStore.ts
@@ -44,7 +44,7 @@ export const mapSearchStore = defineStore({
      */
     async searchMap(query:string) {
         // make the API call to the SPARQL endpoint
-        const url = `${this.apiBaseUrl}/s/sparql`
+        const url = `${this.apiBaseUrl}/sparql`
         this.loading = true
         this.success = false
 

--- a/src/stores/refDataStore.ts
+++ b/src/stores/refDataStore.ts
@@ -42,9 +42,9 @@ export function refDataStore(id:string) {
       /**
        * Calls the SPARQL endpoint with the predefined query, returns a generalised object array from the json response
        */
-      async fetch<T>(subsystem:"s"|"c"|"v", query:string):Promise<void> {
+      async fetch<T>(query:string):Promise<void> {
           // make the API call to the SPARQL endpoint
-          const url = `${this.apiBaseUrl}/${subsystem}/sparql`
+          const url = `${this.apiBaseUrl}/sparql`
           this.loading = true
           this.success = false
 


### PR DESCRIPTION
Changed SPARQL queries in catalog & spatial map search to use `/sparql` instead of `/c/sparql` & `/s/sparql` for listing catalogs & datasets.