### PR TITLE
Security audit, review and update of node dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -719,6 +719,19 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -740,6 +753,18 @@
             "peer": true,
             "dependencies": {
                 "remove-accents": "^0.4.2"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/axios": {
@@ -1150,9 +1175,9 @@
             }
         },
         "node_modules/define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
             "dev": true,
             "dependencies": {
                 "has-property-descriptors": "^1.0.0",
@@ -1212,42 +1237,65 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-            "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+            "version": "1.21.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+            "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
             "dev": true,
             "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
                 "function.prototype.name": "^1.1.5",
-                "get-intrinsic": "^1.1.3",
+                "get-intrinsic": "^1.2.0",
                 "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
                 "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
                 "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.2",
                 "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.10",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.2",
+                "object-inspect": "^1.12.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.4.3",
                 "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
                 "string.prototype.trimend": "^1.0.6",
                 "string.prototype.trimstart": "^1.0.6",
-                "unbox-primitive": "^1.0.2"
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.9"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-to-primitive": {
@@ -1772,6 +1820,15 @@
                 }
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "dependencies": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -1864,12 +1921,13 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
             "dependencies": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3"
             },
             "funding": {
@@ -1924,6 +1982,21 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dev": true,
+            "dependencies": {
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -1937,9 +2010,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/has": {
@@ -1978,6 +2051,17 @@
             "dev": true,
             "dependencies": {
                 "get-intrinsic": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2116,12 +2200,12 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/internal-slot": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.1.0",
+                "get-intrinsic": "^1.2.0",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             },
@@ -2136,6 +2220,20 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-arrayish": {
@@ -2335,6 +2433,25 @@
             "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2718,9 +2835,9 @@
             "dev": true
         },
         "node_modules/object-inspect": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+            "version": "1.12.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3133,14 +3250,14 @@
             "peer": true
         },
         "node_modules/regexp.prototype.flags": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-            "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+            "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "functions-have-names": "^1.2.2"
+                "define-properties": "^1.2.0",
+                "functions-have-names": "^1.2.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3406,9 +3523,9 @@
             "deprecated": "Please use @jridgewell/sourcemap-codec instead"
         },
         "node_modules/spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
@@ -3432,9 +3549,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+            "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
             "dev": true
         },
         "node_modules/split-on-first": {
@@ -3478,6 +3595,23 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.4.tgz",
             "integrity": "sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+            "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -3589,9 +3723,9 @@
             }
         },
         "node_modules/superagent/node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -3732,6 +3866,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/typescript": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -3795,9 +3943,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
-            "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+            "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
             "dependencies": {
                 "esbuild": "^0.15.9",
                 "postcss": "^8.4.18",
@@ -4072,6 +4220,26 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4704,6 +4872,16 @@
                 "picomatch": "^2.0.4"
             }
         },
+        "array-buffer-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "is-array-buffer": "^3.0.1"
+            }
+        },
         "assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -4723,6 +4901,12 @@
             "requires": {
                 "remove-accents": "^0.4.2"
             }
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "dev": true
         },
         "axios": {
             "version": "1.3.4",
@@ -5036,9 +5220,9 @@
             "peer": true
         },
         "define-properties": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+            "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
             "dev": true,
             "requires": {
                 "has-property-descriptors": "^1.0.0",
@@ -5080,36 +5264,56 @@
             }
         },
         "es-abstract": {
-            "version": "1.20.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-            "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+            "version": "1.21.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+            "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
             "dev": true,
             "requires": {
+                "array-buffer-byte-length": "^1.0.0",
+                "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
+                "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
                 "function.prototype.name": "^1.1.5",
-                "get-intrinsic": "^1.1.3",
+                "get-intrinsic": "^1.2.0",
                 "get-symbol-description": "^1.0.0",
+                "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
                 "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.3",
+                "internal-slot": "^1.0.5",
+                "is-array-buffer": "^3.0.2",
                 "is-callable": "^1.2.7",
                 "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.2",
                 "is-string": "^1.0.7",
+                "is-typed-array": "^1.1.10",
                 "is-weakref": "^1.0.2",
-                "object-inspect": "^1.12.2",
+                "object-inspect": "^1.12.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.4.3",
                 "safe-regex-test": "^1.0.0",
+                "string.prototype.trim": "^1.2.7",
                 "string.prototype.trimend": "^1.0.6",
                 "string.prototype.trimstart": "^1.0.6",
-                "unbox-primitive": "^1.0.2"
+                "typed-array-length": "^1.0.4",
+                "unbox-primitive": "^1.0.2",
+                "which-typed-array": "^1.1.9"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+            "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.3",
+                "has": "^1.0.3",
+                "has-tostringtag": "^1.0.0"
             }
         },
         "es-to-primitive": {
@@ -5387,6 +5591,15 @@
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
             "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
         },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -5450,12 +5663,13 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
             "requires": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
+                "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3"
             }
         },
@@ -5492,6 +5706,15 @@
                 "is-glob": "^4.0.1"
             }
         },
+        "globalthis": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3"
+            }
+        },
         "gopd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5502,9 +5725,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "has": {
@@ -5535,6 +5758,11 @@
             "requires": {
                 "get-intrinsic": "^1.1.1"
             }
+        },
+        "has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
         },
         "has-symbols": {
             "version": "1.0.3",
@@ -5628,12 +5856,12 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "internal-slot": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+            "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
             "dev": true,
             "requires": {
-                "get-intrinsic": "^1.1.0",
+                "get-intrinsic": "^1.2.0",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             }
@@ -5643,6 +5871,17 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
+        },
+        "is-array-buffer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "is-typed-array": "^1.1.10"
+            }
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -5778,6 +6017,19 @@
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
             }
         },
         "is-weakref": {
@@ -6062,9 +6314,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+            "version": "1.12.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
         },
         "object-keys": {
             "version": "1.1.1",
@@ -6336,14 +6588,14 @@
             "peer": true
         },
         "regexp.prototype.flags": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-            "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+            "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "functions-have-names": "^1.2.2"
+                "define-properties": "^1.2.0",
+                "functions-have-names": "^1.2.3"
             }
         },
         "remove-accents": {
@@ -6513,9 +6765,9 @@
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
         },
         "spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -6539,9 +6791,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-            "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+            "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
             "dev": true
         },
         "split-on-first": {
@@ -6576,6 +6828,17 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.4.tgz",
             "integrity": "sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+            "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -6659,9 +6922,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "version": "7.5.3",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+                    "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -6765,6 +7028,17 @@
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
+        "typed-array-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "is-typed-array": "^1.1.9"
+            }
+        },
         "typescript": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -6815,9 +7089,9 @@
             }
         },
         "vite": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
-            "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+            "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
             "requires": {
                 "esbuild": "^0.15.9",
                 "fsevents": "~2.3.2",
@@ -6982,6 +7256,20 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.10"
             }
         },
         "word-wrap": {


### PR DESCRIPTION
Fixes https://github.com/RDFLib/prez-ui/issues/76.

Branched off main on commit https://github.com/RDFLib/prez-ui/tree/ed9543588cdcd385214498b8c5fe508c1282edd9.

This PR fixes the `vite` security issue detailed in the `npm audit` command. It fixes it by bumping the minor and patch versions of the affected packages in `package-lock.json`.

<details>
<summary><code>npm audit</code></summary>

```
# npm audit report

semver  <7.5.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install npm-run-all@4.1.2, which is a breaking change
node_modules/semver
node_modules/superagent/node_modules/semver
  cross-spawn  6.0.0 - 6.0.5
  Depends on vulnerable versions of semver
  node_modules/cross-spawn
    npm-run-all  >=1.8.0
    Depends on vulnerable versions of cross-spawn
    Depends on vulnerable versions of read-pkg
    node_modules/npm-run-all
  normalize-package-data  <=2.5.0
  Depends on vulnerable versions of semver
  node_modules/normalize-package-data
    read-pkg  <=5.2.0
    Depends on vulnerable versions of normalize-package-data
    node_modules/read-pkg

vite  3.0.2 - 3.2.6
Severity: high
Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//) - https://github.com/advisories/GHSA-353f-5xf4-qw67
fix available via `npm audit fix`
node_modules/vite

word-wrap  *
Severity: moderate
word-wrap vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-j8xg-fqg3-53r7
fix available via `npm audit fix`
node_modules/word-wrap
  optionator  0.8.3 - 0.9.1
  Depends on vulnerable versions of word-wrap
  node_modules/optionator

8 vulnerabilities (7 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

</details>

---

### semver

Running the `npm explain semver` command shows a set of dev and prod dependencies using the `semver` package. There's nothing to do with the dev dependencies as these vulnerabilities do not exist once we perform a production build.

However, the prod dependencies using affected `semver` package are all from the `@triply` family of [YASQUI](https://github.com/TriplyDB/Yasgui) packages.

Details of the vulnerability is here https://github.com/advisories/GHSA-c2qf-rxjj-qqgw, and the vulnerability description is:

> Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.

The YASGUI packages use `semver` via `superagent`, which does not use the Range function. See https://github.com/search?q=repo%3Aladjs%2Fsuperagent+semver&type=code. 

**Action**: Conclusion for now is, it is safe to use YASGUI with this vulnerability there, as long as `superagent` does not use the Range function.

<details>
<summary><code>npm explain semver</code></summary>

```
semver@5.7.1 dev
node_modules/semver
  semver@"^5.5.0" from cross-spawn@6.0.5
  node_modules/cross-spawn
    cross-spawn@"^6.0.5" from npm-run-all@4.1.5
    node_modules/npm-run-all
      dev npm-run-all@"^4.1.5" from the root project
  semver@"2 || 3 || 4 || 5" from normalize-package-data@2.5.0
  node_modules/normalize-package-data
    normalize-package-data@"^2.3.2" from read-pkg@3.0.0
    node_modules/read-pkg
      read-pkg@"^3.0.0" from npm-run-all@4.1.5
      node_modules/npm-run-all
        dev npm-run-all@"^4.1.5" from the root project

semver@7.5.3
node_modules/superagent/node_modules/semver
  semver@"^7.3.2" from superagent@5.3.1
  node_modules/superagent
    superagent@"5.3.1" from @triply/yasgui@4.2.28
    node_modules/@triply/yasgui
      peer @triply/yasgui@"4.x" from @triply/yasqe@4.2.28
      node_modules/@triply/yasqe
        @triply/yasqe@"^4.2.28" from the root project
        @triply/yasqe@"^4.2.28" from @triply/yasgui@4.2.28
        @triply/yasqe@"^4.2.28" from @triply/yasr@4.2.28
        node_modules/@triply/yasr
          @triply/yasr@"^4.2.28" from the root project
          @triply/yasr@"^4.2.28" from @triply/yasgui@4.2.28
      peer @triply/yasgui@"4.x" from @triply/yasr@4.2.28
      node_modules/@triply/yasr
        @triply/yasr@"^4.2.28" from the root project
        @triply/yasr@"^4.2.28" from @triply/yasgui@4.2.28
    superagent@"5.3.1" from @triply/yasqe@4.2.28
    node_modules/@triply/yasqe
      @triply/yasqe@"^4.2.28" from the root project
      @triply/yasqe@"^4.2.28" from @triply/yasgui@4.2.28
      @triply/yasqe@"^4.2.28" from @triply/yasr@4.2.28
      node_modules/@triply/yasr
        @triply/yasr@"^4.2.28" from the root project
        @triply/yasr@"^4.2.28" from @triply/yasgui@4.2.28
```

</details>

---

### word-wrap

Running the `npm explain word-wrap` command shows a set of dev packages depending on `word-wrap`. Since these are dev dependencies, they are not an issue in Prez UI in the production build.

**Action**: Nothing to do as `word-wrap` is used by dev dependencies.

<details>
<summary><code>npm explain word-wrap</code></summary>

```
word-wrap@1.2.3 dev
node_modules/word-wrap
  word-wrap@"~1.2.3" from optionator@0.8.3
  node_modules/optionator
    optionator@"^0.8.1" from escodegen@2.0.0
    node_modules/escodegen
      escodegen@"^2.0.0" from jsdom@20.0.3
      node_modules/jsdom
        dev jsdom@"^20.0.3" from the root project
        peerOptional jsdom@"*" from vitest@0.25.5
        node_modules/vitest
          dev vitest@"^0.25.3" from the root project
```

</details>
