### PR TITLE
Implemented labels for objects, bnodes & types in PropTable

### DIFF
--- a/src/components/PaginationComponent.vue
+++ b/src/components/PaginationComponent.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch } from "vue";
 import { RouterLink } from "vue-router";
 import router from "@/router";
 
-const PER_PAGE = 10;
+const PER_PAGE = 20;
 
 const props = defineProps<{
     totalCount: number;

--- a/src/components/proptable/ObjCell.vue
+++ b/src/components/proptable/ObjCell.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { RowObj } from "@/types";
 import PropRow from "@/components/proptable/PropRow.vue";
+import ToolTip from "@/components/ToolTip.vue";
 
 const props = defineProps<RowObj>();
 
@@ -19,22 +20,21 @@ function copyString(s: string) {
 <template>
     <div class="prop-obj">
         <div class="obj-value">
-            <template v-if="props.termType === 'BlankNode'">
-                <table>
-                    <PropRow v-for="row in props.rows" v-bind="row" />
-                </table>
-            </template>
-            <template v-else-if="props.termType === 'NamedNode'">
-                <template v-if="!!props.label">
-                    <a :href="props.value" target="_blank" rel="noopener noreferrer">{{ props.label }}</a>
-                </template>
-                <template v-else-if="!!props.qname">
-                    <a :href="props.value" target="_blank" rel="noopener noreferrer">{{ props.qname }}</a>
-                </template>
-                <template v-else>
-                    <a :href="props.value" target="_blank" rel="noopener noreferrer">{{ props.value }}</a>
-                </template>
-            </template>
+            <table v-if="props.termType === 'BlankNode'">
+                <PropRow v-for="row in props.rows" v-bind="row" />
+            </table>
+            <component v-else-if="props.termType === 'NamedNode'" :is="!!props.description ? ToolTip : 'slot'">
+                <a
+                    :href="props.value"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <template v-if="!!props.label">{{ props.label }}</template>
+                    <template v-else-if="!!props.qname">{{ props.qname }}</template>
+                    <template v-else>{{ props.value }}</template>
+                </a>
+                <template #text>{{ props.description }}</template>
+            </component>
             <template v-else>
                 <template v-if="props.value.startsWith('http')">
                     <a :href="props.value" target="_blank" rel="noopener noreferrer">{{ props.value }}</a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey } from "vue";
-import type { Quad } from "n3";
+import type { Quad, NamedNode } from "n3";
 
 export type PrezFlavour = "CatPrez" | "SpacePrez" | "VocPrez";
 
@@ -89,7 +89,13 @@ export interface ListItem {
     title?: string;
     description?: string;
     link?: string;
-    type?: string;
+    baseClass?: string;
+    types?: {
+        value: string;
+        qname?: string;
+        label?: string;
+        description?: string;
+    }[];
 };
 
 // extra properies for SortableTable display go in extras
@@ -112,8 +118,18 @@ export interface AnnotatedPredicate {
     annotations: Quad[];
 };
 
-export interface AnnotatedQuad extends Omit<Quad, "predicate"> {
+export interface AnnotatedObject {
+    termType: "NamedNode" | "Variable" | "Literal" | "BlankNode";
+    value: string;
+    id: string;
+    language?: string;
+    datatype?: NamedNode;
+    annotations: Quad[];
+};
+
+export interface AnnotatedQuad extends Omit<Quad, "predicate" | "object"> {
     predicate: AnnotatedPredicate;
+    object: AnnotatedObject;
 };
 
 export interface RowObj {
@@ -125,6 +141,7 @@ export interface RowObj {
     };
     language?: string;
     description?: string;
+    explanation?: string;
     termType: string;
     label?: string;
     rows: RowPred[];

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref, computed, onMounted, inject, onBeforeMount } from "vue";
 import { useRoute } from "vue-router";
-import { BlankNode, DataFactory, Quad, Store } from "n3";
+import { BlankNode, DataFactory, Quad, Store, Literal } from "n3";
 import { useUiStore } from "@/stores/ui";
 import { useRdfStore } from "@/composables/rdfStore";
 import { useGetRequest } from "@/composables/api";
@@ -60,9 +60,9 @@ const childrenConfig = ref({
     buttonLink: ""
 });
 
-function configByType(type: string) {
-    item.value.type = type;
-    switch (type) {
+function configByBaseClass(baseClass: string) {
+    item.value.baseClass = baseClass;
+    switch (baseClass) {
         case qname("dcat:Catalog"):
             searchEnabled.value = true;
             searchDefaults.value = { catalog: item.value.iri };
@@ -121,8 +121,11 @@ function configByType(type: string) {
 
 function getProperties() {
     // find subject
-    const subject = isObjectView.value ? namedNode(route.query.uri as string) : store.value.getSubjects(namedNode(qname("a")), namedNode(item.value.type!), null)[0];
-    item.value.iri = subject.id;
+    const subject = isObjectView.value ? namedNode(route.query.uri as string) : store.value.getSubjects(namedNode(qname("a")), namedNode(item.value.baseClass!), null)[0];
+    item.value = {
+        iri: subject.id,
+        types: []
+    };
 
     // get label & description predicates
     const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
@@ -138,8 +141,18 @@ function getProperties() {
         } else if (DEFAULT_CHILDREN_PREDICATES.includes(q.predicate.value)) {
             childrenPredicate.value = q.predicate.value;
             hiddenPredicates.value.push(q.predicate.value);
-        } else if (q.predicate.value === qname("a") && isObjectView.value) {
-            configByType(q.object.value);
+        } else if (q.predicate.value === qname("a")) {
+            configByBaseClass(q.object.value); // might not be needed anymore with the /object changes
+            const typeLabel = store.value.getObjects(q.object, namedNode(qname("rdfs:label")), null);
+            const typeDesc = store.value.getObjects(q.object, namedNode(qname("dcterms:description")), null);
+            const typeQname = getQname(q.object.value);
+
+            item.value.types!.push({
+                value: q.object.value,
+                qname: typeQname !== "" ? typeQname : undefined,
+                label: typeLabel.length > 0 ? typeLabel[0].value : undefined,
+                description: typeDesc.length > 0 ? typeDesc[0].value : undefined,
+            });
         } else if (DEFAULT_GEO_PREDICATES.indexOf(q.predicate.value) >= 0) {
             store.value.forEach(geoQ => {
                 geoResults.value.push({
@@ -250,7 +263,7 @@ function getIRILocalName(iri: string) {
 }
 
 function getChildren() {
-    if (item.value.type === qname("skos:ConceptScheme")) {
+    if (item.value.baseClass === qname("skos:ConceptScheme")) {
         getConcepts();
     } else {
         const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
@@ -267,8 +280,8 @@ function getChildren() {
                 } else if (q.predicate.value === qname("prez:link")) {
                     child.link = q.object.value;
                 } else if (q.predicate.value === qname("a")) {
-                    child.type = q.object.value;
-                } else if (item.value.type === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:publisher")) {
+                    child.baseClass = q.object.value;
+                } else if (item.value.baseClass === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:publisher")) {
                     const publisher: ListItemSortable = { iri: q.object.value, label: getIRILocalName(q.object.value) };
 
                     store.value.forObjects(result => {
@@ -276,7 +289,7 @@ function getChildren() {
                     }, q.object, qname("rdfs:label"), null);
 
                     child.extras.publisher = publisher;
-                } else if (item.value.type === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:creator")) {
+                } else if (item.value.baseClass === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:creator")) {
                     const creator: ListItemSortable = { iri: q.object.value, label: getIRILocalName(q.object.value) };
 
                     store.value.forObjects(result => {
@@ -284,7 +297,7 @@ function getChildren() {
                     }, q.object, qname("rdfs:label"), null);
                     
                     child.extras.creator = creator;
-                } else if (item.value.type === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:issued")) {
+                } else if (item.value.baseClass === qname("dcat:Catalog") && q.predicate.value === qname("dcterms:issued")) {
                     const issued: ListItemSortable = { label: q.object.value };
                     child.extras.issued = issued;
                 } 
@@ -373,7 +386,14 @@ function createAnnoQuad(q: Quad, store: Store): AnnotatedQuad {
             id: q.predicate.id,
             annotations: store.getQuads(q.predicate, null, null, null)
         },
-        object: q.object,
+        object: {
+            termType: q.object.termType,
+            value: q.object.value,
+            id: q.object.id,
+            datatype: q.object instanceof Literal ? q.object.datatype : undefined,
+            language: q.object instanceof Literal ? q.object.language : undefined,
+            annotations: store.getQuads(q.object, null, null, null)
+        },
         value: q.value,
         graph: q.graph,
         termType: q.termType,
@@ -395,44 +415,54 @@ function findBlankNodes(q: Quad, store: Store, recursionCounter: number) {
     }
 }
 
+function getQname(iri: string): string {
+    let qname = "";
+    Object.entries(prefixes).forEach(([prefix, prefixIri]) => {
+        if (iri.startsWith(prefixIri)) {
+            qname = prefix + ":" + iri.split(prefixIri)[1];
+        }
+    });
+    return qname;
+}
+
 onBeforeMount(() => {
     // inspect route to infer type & Prez flavour
     if (route.path.startsWith("/c/")) {
         flavour.value = "CatPrez";
         if (route.path.match(/c\/profiles\/.+/)) {
-            configByType(qname("prof:Profile"));
+            configByBaseClass(qname("prof:Profile"));
         } else if (route.path.match(/c\/catalogs\/.+\/.+/)) {
-            configByType(qname("dcat:Resource"));
+            configByBaseClass(qname("dcat:Resource"));
         } else if (route.path.match(/c\/catalogs\/.+/)) {
-            configByType(qname("dcat:Catalog"));
+            configByBaseClass(qname("dcat:Catalog"));
         }
     } else if (route.path.startsWith("/s/")) {
         flavour.value = "SpacePrez";
         if (route.path.match(/s\/profiles\/.+/)) {
-            configByType(qname("prof:Profile"));
+            configByBaseClass(qname("prof:Profile"));
         } else if (route.path.match(/s\/datasets\/.+\/collections\/.+\/items\/.+/)) {
-            configByType(qname("geo:Feature"));
+            configByBaseClass(qname("geo:Feature"));
         } else if (route.path.match(/s\/datasets\/.+\/collections\/.+/)) {
-            configByType(qname("geo:FeatureCollection"));
+            configByBaseClass(qname("geo:FeatureCollection"));
         } else if (route.path.match(/s\/datasets\/.+/)) {
-            configByType(qname("dcat:Dataset"));
+            configByBaseClass(qname("dcat:Dataset"));
         }
     } else if (route.path.startsWith("/v/")) {
         flavour.value = "VocPrez";
         if (route.path.match(/v\/profiles\/.+/)) {
-            configByType(qname("prof:Profile"));
+            configByBaseClass(qname("prof:Profile"));
         } else if (route.path.match(/v\/vocab\/.+\/.+/)) {
-            configByType(qname("skos:Concept"));
+            configByBaseClass(qname("skos:Concept"));
         } else if (route.path.match(/v\/collection\/.+\/.+/)) {
             // concept in collection
-            configByType(qname("skos:Concept"));
+            configByBaseClass(qname("skos:Concept"));
         } else if (route.path.match(/v\/vocab\/.+/)) {
-            configByType(qname("skos:ConceptScheme"));
+            configByBaseClass(qname("skos:ConceptScheme"));
         } else if (route.path.match(/v\/collection\/.+/)) {
-            configByType(qname("skos:Collection"));
+            configByBaseClass(qname("skos:Collection"));
         }
     } else if (route.path.startsWith("/profiles/")) {
-        configByType(qname("prof:Profile"));
+        configByBaseClass(qname("prof:Profile"));
     } else if (route.path.startsWith("/object")) {
         isObjectView.value = true;
     }
@@ -488,7 +518,7 @@ onMounted(() => {
                         :geo-w-k-t="geoResults"
                     />
             </template>
-            <template v-if="item.type === qname('skos:ConceptScheme')" #bottom>
+            <template v-if="item.baseClass === qname('skos:ConceptScheme')" #bottom>
                 <tr>
                     <th>Concepts</th>
                     <td>
@@ -506,7 +536,7 @@ onMounted(() => {
                 <tr>
                     <th>{{ childrenConfig.childrenTitle }}</th>
                     <SortableTabularList
-                        v-if="item.type === qname('dcat:Catalog')"
+                        v-if="item.baseClass === qname('dcat:Catalog')"
                         :items="children"
                         :predicates="['publisher', 'creator', 'issued']"
                     />


### PR DESCRIPTION
All objects & blank node tables now display labels when available, as well as the item type.

Resolves #73, resolves #32.