### PR TITLE
Renamed qname() function, other small refactors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,9 +24,9 @@ const ui = useUiStore();
 
 const { data, profiles, loading, error, doRequest } = useGetRequest();
 const { data: profData, profiles: profProfiles, loading: profLoading, error: profError, doRequest: profDoRequest } = useGetRequest();
-const { store, prefixes, parseIntoStore, qname } = useRdfStore();
-const { store: profStore, prefixes: profPrefixes, parseIntoStore: profParseIntoStore, qname: profQname } = useRdfStore();
-const { store: combinedStore, prefixes: combinedPrefixes, parseIntoStore: combinedParseIntoStore, qname: combinedQname } = useRdfStore();
+const { store, prefixes, parseIntoStore, qnameToIri } = useRdfStore();
+const { store: profStore, prefixes: profPrefixes, parseIntoStore: profParseIntoStore, qnameToIri: profQnameToIri } = useRdfStore();
+const { store: combinedStore, prefixes: combinedPrefixes, parseIntoStore: combinedParseIntoStore, qnameToIri: combinedQnameToIri } = useRdfStore();
 
 document.title = ui.pageTitle;
 
@@ -47,8 +47,8 @@ onMounted(() => {
                         token: q.object.value.replace("/profiles/", ""),
                         link: `${apiBaseUrl}${q.object.value}`
                     }
-                }, subject, namedNode(profQname("prez:link")), null, null);
-            }, namedNode(profQname("a")), namedNode(profQname("prof:Profile")), null);
+                }, subject, namedNode(profQnameToIri("prez:link")), null, null);
+            }, namedNode(profQnameToIri("a")), namedNode(profQnameToIri("prof:Profile")), null);
             
             // promise.all request for each profile in parallel
             Promise.all(Object.values(profileUris).map(p => fetch(p.link).then(r => r.text()))).then(values => {
@@ -72,27 +72,27 @@ onMounted(() => {
                         explanationPredicates: []
                     };
                     combinedStore.value.forEach(q => {
-                        if (q.predicate.value === combinedQname("dcterms:title")) {
+                        if (q.predicate.value === combinedQnameToIri("dcterms:title")) {
                             p.title = q.object.value;
-                        } else if (q.predicate.value === combinedQname("dcterms:description")) {
+                        } else if (q.predicate.value === combinedQnameToIri("dcterms:description")) {
                             p.description = q.object.value;
-                        // } else if (q.predicate.value === combinedQname("dcterms:identifier")) {
+                        // } else if (q.predicate.value === combinedQnameToIri("dcterms:identifier")) {
                         //     p.token = q.object.value;
-                        } else if (q.predicate.value === combinedQname("altr-ext:hasResourceFormat")) {
+                        } else if (q.predicate.value === combinedQnameToIri("altr-ext:hasResourceFormat")) {
                             p.mediatypes.push(q.object.value);
-                        } else if (q.predicate.value === combinedQname("altr-ext:hasDefaultResourceFormat")) {
+                        } else if (q.predicate.value === combinedQnameToIri("altr-ext:hasDefaultResourceFormat")) {
                             p.defaultMediatype = q.object.value;
-                        } else if (q.predicate.value === combinedQname("altr-ext:hasLabelPredicate")) {
+                        } else if (q.predicate.value === combinedQnameToIri("altr-ext:hasLabelPredicate")) {
                             p.labelPredicates.push(q.object.value);
-                        } else if (q.predicate.value === combinedQname("altr-ext:hasDescriptionPredicate")) {
+                        } else if (q.predicate.value === combinedQnameToIri("altr-ext:hasDescriptionPredicate")) {
                             p.descriptionPredicates.push(q.object.value);
-                        } else if (q.predicate.value === combinedQname("altr-ext:hasExplanationPredicate")) {
+                        } else if (q.predicate.value === combinedQnameToIri("altr-ext:hasExplanationPredicate")) {
                             p.explanationPredicates.push(q.object.value);
                         }
                     }, subject, null, null, null);
                     p.mediatypes.sort((a, b) => Number(b === p.defaultMediatype) - Number(a === p.defaultMediatype));
                     profs.push(p);
-                }, namedNode(combinedQname("a")), namedNode(combinedQname("prof:Profile")), null);
+                }, namedNode(combinedQnameToIri("a")), namedNode(combinedQnameToIri("prof:Profile")), null);
 
                 ui.profiles = profs.reduce<{[namespace: string]: Profile}>((obj, prof) => (obj[prof.namespace] = prof, obj), {}); // {uri: {...}, ...}
             });
@@ -104,7 +104,7 @@ onMounted(() => {
         parseIntoStore(data.value);
 
         // get API version
-        const version = store.value.getObjects(null, qname("prez:version"), null)[0];
+        const version = store.value.getObjects(null, qnameToIri("prez:version"), null)[0];
         ui.apiVersion = version.value;
 
         // get search methods per flavour
@@ -113,14 +113,14 @@ onMounted(() => {
             let flavour = "";
             let methods: string[] = [];
             store.value.forEach(q => {
-                if (q.predicate.value === qname("a")) {
-                    flavour = q.object.value.split(`${qname('prez:')}`)[1];
-                } else if (q.predicate.value === qname("prez:availableSearchMethod")) {
-                    methods.push(q.object.value.split(`${qname('prez:')}`)[1]);
+                if (q.predicate.value === qnameToIri("a")) {
+                    flavour = q.object.value.split(`${qnameToIri('prez:')}`)[1];
+                } else if (q.predicate.value === qnameToIri("prez:availableSearchMethod")) {
+                    methods.push(q.object.value.split(`${qnameToIri('prez:')}`)[1]);
                 }
             }, object, null, null, null);
             searchMethods[flavour] = methods;
-        }, null, qname("prez:enabledPrezFlavour"), null);
+        }, null, qnameToIri("prez:enabledPrezFlavour"), null);
         ui.searchMethods = searchMethods;
     });
 });

--- a/src/components/proptable/ObjCell.vue
+++ b/src/components/proptable/ObjCell.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { RowObj } from "@/types";
+import { copyToClipboard } from "@/util/helpers";
 import PropRow from "@/components/proptable/PropRow.vue";
 
 const props = defineProps<RowObj>();
@@ -10,10 +11,6 @@ const geometryPreds = [
 ];
 
 const MAX_GEOM_LENGTH = 100; // max character length for geometry strings
-
-function copyString(s: string) {
-    navigator.clipboard.writeText(s.trim());
-}
 </script>
 
 <template>
@@ -41,7 +38,7 @@ function copyString(s: string) {
                 </template>
                 <div v-else-if="props.datatype && geometryPreds.includes(props.datatype.value)" class="geom-cell">
                     <pre>{{ props.value.length > MAX_GEOM_LENGTH ? `${props.value.slice(0, MAX_GEOM_LENGTH)}...` : props.value }}</pre>
-                    <button class="btn outline sm" title="Copy geometry" @click="copyString(props.value)"><i class="fa-regular fa-clipboard"></i></button>
+                    <button class="btn outline sm" title="Copy geometry" @click="copyToClipboard(props.value)"><i class="fa-regular fa-clipboard"></i></button>
                 </div>
                 <template v-else>{{ props.value }}</template>
             </template>

--- a/src/components/proptable/PropTable.vue
+++ b/src/components/proptable/PropTable.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { BlankNode, Literal, NamedNode } from "n3";
 import type { AnnotatedPredicate, AnnotatedQuad, ListItem, RowPred } from "@/types";
+import { copyToClipboard } from "@/util/helpers";
 import PropRow from "@/components/proptable/PropRow.vue";
 
 const props = defineProps<{
@@ -14,17 +15,17 @@ const props = defineProps<{
 
 const rows = ref<RowPred[]>([]);
 
-function getNamedNodeQname(n: NamedNode | AnnotatedPredicate): string {
+function iriToQname(iri: string): string { // doesn't require a store, uses prefixes from props
     let qname = "";
     Object.entries(props.prefixes).forEach(([prefix, prefixIri]) => {
-        if (n.value.startsWith(prefixIri)) {
-            qname = prefix + ":" + n.value.split(prefixIri)[1];
+        if (iri.startsWith(prefixIri)) {
+            qname = prefix + ":" + iri.split(prefixIri)[1];
         }
     });
     return qname;
 }
 
-function qname(s: string): string {
+function qnameToIri(s: string): string { // doesn't require a store, uses prefixes from props
     if (s === "a") { // special handling for "a" as rdf:type
         return props.prefixes.rdf + "type";
     } else {
@@ -34,7 +35,7 @@ function qname(s: string): string {
 }
 
 function getAnnotation(predicate: AnnotatedPredicate, annotationPred: string): string | undefined {
-    return predicate.annotations.find(annotation => annotation.predicate.value === qname(annotationPred))?.object.value;
+    return predicate.annotations.find(annotation => annotation.predicate.value === qnameToIri(annotationPred))?.object.value;
 }
 
 function copyIri() {
@@ -47,7 +48,7 @@ function buildRows(properties: AnnotatedQuad[]): RowPred[] {
         propRows[p.predicate.value] ??= {
             iri: p.predicate.value,
             objs: [],
-            qname: getNamedNodeQname(p.predicate),
+            qname: iriToQname(p.predicate.value),
             label: getAnnotation(p.predicate, "rdfs:label"),
             description: getAnnotation(p.predicate, "dcterms:description"),
             explanation: getAnnotation(p.predicate, "dcterms:provenance"),
@@ -56,8 +57,8 @@ function buildRows(properties: AnnotatedQuad[]): RowPred[] {
 
         propRows[p.predicate.value].objs.push({
             value: p.object.value,
-            qname: p.object instanceof NamedNode ? getNamedNodeQname(p.object) : undefined,
-            datatype: p.object instanceof Literal ? { value: p.object.datatype.value, qname: getNamedNodeQname(p.object.datatype) } : undefined,
+            qname: p.object instanceof NamedNode ? iriToQname(p.object.value) : undefined,
+            datatype: p.object instanceof Literal ? { value: p.object.datatype.value, qname: iriToQname(p.object.datatype.value) } : undefined,
             language: p.object instanceof Literal ? p.object.language : undefined,
             description: undefined,
             termType: p.object.termType,
@@ -80,7 +81,7 @@ onMounted(() => {
         <small class="iri">
             <span class="badge">IRI</span>
             <a :href="props.item.iri" target="_blank" rel="noopener noreferrer">{{ props.item.iri }}</a>
-            <button class="btn outline sm" title="Copy IRI" @click="copyIri()"><i class="fa-regular fa-clipboard"></i></button>
+            <button class="btn outline sm" title="Copy IRI" @click="copyToClipboard(props.item.iri)"><i class="fa-regular fa-clipboard"></i></button>
         </small>
         <small class="type">
             <span class="badge">Type</span>

--- a/src/components/search/CatPrezSearch.vue
+++ b/src/components/search/CatPrezSearch.vue
@@ -9,7 +9,7 @@ const { namedNode } = DataFactory;
 
 const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 const { data, loading, error, doRequest } = useGetRequest();
-const { store, parseIntoStore, qname } = useRdfStore();
+const { store, parseIntoStore, qnameToIri } = useRdfStore();
 
 const props = defineProps<{
     defaultSelected?: string;
@@ -44,12 +44,12 @@ onMounted(() => {
             };
             
             store.value.forEach(q => { // get preds & objs for each subj
-                if (q.predicate.value === qname("rdfs:label")) {
+                if (q.predicate.value === qnameToIri("rdfs:label")) {
                     option.title = q.object.value;
                 }
             }, member, null, null, null);
             options.value.push(option);
-        }, namedNode(qname("a")), namedNode(qname("dcat:Catalog")), null);
+        }, namedNode(qnameToIri("a")), namedNode(qnameToIri("dcat:Catalog")), null);
     });
 });
 </script>

--- a/src/components/search/CatPrezSearchMap.vue
+++ b/src/components/search/CatPrezSearchMap.vue
@@ -11,6 +11,8 @@ import { QUERY_GET_CATALOGS, QUERY_GET_THEMES, QUERY_SEARCH } from "@/stores/cat
 import type { RDCatalog, RDSearch, RDTheme } from "@/stores/catalogQueries.d"
 import { shapeQueryPart } from "@/util/mapSearchHelper"
 
+import { copyToClipboard } from "@/util/helpers";
+
 import LoadingMessage from "@/components/LoadingMessage.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
 import BaseModal from "@/components/BaseModal.vue";
@@ -105,10 +107,6 @@ const performSearch = async(event: Event|null=null) => {
     sparqlQueryRef.value = QUERY_SEARCH(selectedCatalogsRef.value, searchTermRef.value, selectedThemesRef.value, shapeQueryPart(coordsRef.value), //limitRef.value);
         (limitRef.value > 0 ? parseInt(limitRef.value.toString()) + 1 : 0));
     await rdSearch.fetch<RDSearch[]>(sparqlQueryRef.value)
-}
-
-function copySPARQL() {
-    navigator.clipboard.writeText(sparqlQueryRef.value);
 }
 
 // start off by loading the main filter lists for catalogs and themes
@@ -242,7 +240,7 @@ onMounted(async ()=>{
             <pre>{{ sparqlQueryRef.trim() }}</pre>
         </div>
         <template #footer>
-            <button class="btn outline sparql-copy-btn" @click="copySPARQL" title="Copy SPARQL query">Copy <i class="fa-regular fa-copy"></i></button>
+            <button class="btn outline sparql-copy-btn" @click="copyToClipboard(sparqlQueryRef)" title="Copy SPARQL query">Copy <i class="fa-regular fa-copy"></i></button>
         </template>
     </BaseModal>
 </template>

--- a/src/components/search/SpacePrezSearch.vue
+++ b/src/components/search/SpacePrezSearch.vue
@@ -9,7 +9,7 @@ const { namedNode } = DataFactory;
 
 const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 const { data, loading, error, doRequest } = useGetRequest();
-const { store, parseIntoStore, qname } = useRdfStore();
+const { store, parseIntoStore, qnameToIri } = useRdfStore();
 
 const props = defineProps<{
     defaultSelected?: {
@@ -73,9 +73,9 @@ onMounted(() => {
             let datasetIRI = member.value;
             
             store.value.forEach(q => { // get preds & objs for each subj
-                if (q.predicate.value === qname("dcterms:title")) {
+                if (q.predicate.value === qnameToIri("dcterms:title")) {
                     option.title = q.object.value;
-                } else if (q.predicate.value === qname("prez:link")) {
+                } else if (q.predicate.value === qnameToIri("prez:link")) {
                     datasetLink = q.object.value;
                 }
             }, member, null, null, null);
@@ -84,7 +84,7 @@ onMounted(() => {
             // get feature collection list
             if (datasetLink !== "") {
                 const { data: collectionData, loading: collectionLoading, error: collectionError, doRequest: collectionDoRequest } = useGetRequest();
-                const { store: collectionStore, parseIntoStore: collectionParseIntoStore, qname: collectionQname } = useRdfStore();
+                const { store: collectionStore, parseIntoStore: collectionParseIntoStore, qnameToIri: collectionQnameToIri } = useRdfStore();
                 
                 collectionDoRequest(`${apiBaseUrl}${datasetLink}/collections`, () => {
                     collectionParseIntoStore(collectionData.value);
@@ -95,15 +95,15 @@ onMounted(() => {
                         };
                         
                         collectionStore.value.forEach(q => { // get preds & objs for each subj
-                            if (q.predicate.value === collectionQname("rdfs:label")) {
+                            if (q.predicate.value === collectionQnameToIri("rdfs:label")) {
                                 option.title = q.object.value;
                             }
                         }, member, null, null, null);
                         collectionOptions.value.push(option);
-                    }, namedNode(datasetIRI), namedNode(collectionQname("rdfs:member")), null);
+                    }, namedNode(datasetIRI), namedNode(collectionQnameToIri("rdfs:member")), null);
                 });
             }
-        }, namedNode(qname("a")), namedNode(qname("dcat:Dataset")), null);
+        }, namedNode(qnameToIri("a")), namedNode(qnameToIri("dcat:Dataset")), null);
     });
 });
 </script>

--- a/src/components/search/SpacePrezSearchMap.vue
+++ b/src/components/search/SpacePrezSearchMap.vue
@@ -21,6 +21,7 @@ import ButtonGroup from "@/components/ButtonGroup.vue";
 import { enumToOptions } from "@/util/mapSearchHelper"
 import { mapSearchStore } from "@/stores/mapSearchStore";
 import type { WKTResult } from "@/stores/mapSearchStore.d"
+import { copyToClipboard } from "@/util/helpers";
 import LoadingMessage from "@/components/LoadingMessage.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
 import BaseModal from "@/components/BaseModal.vue";
@@ -80,10 +81,6 @@ function toggleCollapseDatasets() {
     let collapsed: {[key: string]: boolean} = {};
     Object.keys(datasetCollapse.value).forEach(dataset => collapsed[dataset] = !allDatasetsCollapsed.value);
     datasetCollapse.value = collapsed;
-}
-
-function copySPARQL() {
-    navigator.clipboard.writeText(sparqlQueryRef.value);
 }
 
 /** Selects/unselects all datasets & feature collections */
@@ -301,7 +298,7 @@ const toggleAllFeatures = async (datasetNode: DatasetTreeNode, checked: boolean)
             <pre>{{ sparqlQueryRef.trim() }}</pre>
         </div>
         <template #footer>
-            <button class="btn outline sparql-copy-btn" @click="copySPARQL" title="Copy SPARQL query">Copy <i class="fa-regular fa-copy"></i></button>
+            <button class="btn outline sparql-copy-btn" @click="copyToClipboard(sparqlQueryRef)" title="Copy SPARQL query">Copy <i class="fa-regular fa-copy"></i></button>
         </template>
     </BaseModal>
 </template>

--- a/src/components/search/VocPrezSearch.vue
+++ b/src/components/search/VocPrezSearch.vue
@@ -9,7 +9,7 @@ const { namedNode } = DataFactory;
 
 const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 const { data, loading, error, doRequest } = useGetRequest();
-const { store, parseIntoStore, qname } = useRdfStore();
+const { store, parseIntoStore, qnameToIri } = useRdfStore();
 
 const props = defineProps<{
     defaultSelected?: string;
@@ -44,12 +44,12 @@ onMounted(() => {
             };
             
             store.value.forEach(q => { // get preds & objs for each subj
-                if (q.predicate.value === qname("skos:prefLabel")) {
+                if (q.predicate.value === qnameToIri("skos:prefLabel")) {
                     option.title = q.object.value;
                 }
             }, member, null, null, null);
             options.value.push(option);
-        }, namedNode(qname("a")), namedNode(qname("skos:ConceptScheme")), null);
+        }, namedNode(qnameToIri("a")), namedNode(qnameToIri("skos:ConceptScheme")), null);
     });
 });
 </script>

--- a/src/composables/rdfStore.ts
+++ b/src/composables/rdfStore.ts
@@ -52,13 +52,31 @@ export function useRdfStore() {
      * @param {String} s qname string
      * @returns Predicate IRI string
      */
-    function qname(s: string) {
+    function qnameToIri(s: string): string {
         if (s === "a") { // special handling for "a" as rdf:type
             return prefixes.value.rdf + "type";
         } else {
             const [prefix, pred] = s.split(":");
             return prefixes.value[prefix] + pred;
         }
+    }
+
+    /**
+     * Generates a qname from an IRI
+     * 
+     * Note: must be called after `parseIntoStore()`
+     * 
+     * @param iri the IRI string
+     * @returns Generated qname
+     */
+    function iriToQname(iri: string): string {
+        let qname = "";
+        Object.entries(prefixes.value).forEach(([prefix, prefixIri]) => {
+            if (iri.startsWith(prefixIri)) {
+                qname = prefix + ":" + iri.split(prefixIri)[1];
+            }
+        });
+        return qname;
     }
 
     function clearStore() {
@@ -79,5 +97,5 @@ export function useRdfStore() {
     //     return s;
     // }
 
-    return { store, prefixes, parseIntoStore, qname, clearStore };
+    return { store, prefixes, parseIntoStore, qnameToIri, iriToQname, clearStore };
 }

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -20,3 +20,12 @@ export function ensureProfiles() {
         })();
     });
 };
+
+/**
+ * Copies text to the clipboard
+ * 
+ * @param text The text to copy to the clipboard
+ */
+export function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text.trim());
+}

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -12,6 +12,7 @@ import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
 import ErrorMessage from "@/components/ErrorMessage.vue";
 import type { WKTResult } from "@/stores/mapSearchStore.d";
 import { DataFactory } from "n3";
+
 const { namedNode } = DataFactory;
 
 interface SearchResult {
@@ -24,7 +25,7 @@ const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 const route = useRoute();
 const ui = useUiStore();
 const { data, loading, error, doRequest } = useGetRequest();
-const { store, prefixes, parseIntoStore, qname } = useRdfStore();
+const { store, prefixes, parseIntoStore, qnameToIri } = useRdfStore();
 
 const query = ref(route.query as {[key: string]: string});
 const results = ref<SearchResult[]>([]);
@@ -44,16 +45,16 @@ function getResults() {
                 let resultCoordinates = undefined;
 
                 store.value.forEach(q => {
-                    if ([qname("skos:prefLabel"), qname("dcterms:title"), qname("rdfs:label")].includes(q.predicate.value)) {
+                    if ([qnameToIri("skos:prefLabel"), qnameToIri("dcterms:title"), qnameToIri("rdfs:label")].includes(q.predicate.value)) {
                         resultLabel = q.object.value;
                     }
-                    if (q.predicate.value === qname("prez:searchResultSource") ) {
-                        resultSource = q.object.value.replace(qname("prez:"), "");
+                    if (q.predicate.value === qnameToIri("prez:searchResultSource") ) {
+                        resultSource = q.object.value.replace(qnameToIri("prez:"), "");
                     }
-                    if (q.predicate.value === qname("geo:hasGeometry")) {
+                    if (q.predicate.value === qnameToIri("geo:hasGeometry")) {
                         store.value.forEach(geometryTriple => {
                             resultCoordinates = geometryTriple.object.value;
-                        }, q.object, namedNode(qname("geo:asWKT")),  null, null);
+                        }, q.object, namedNode(qnameToIri("geo:asWKT")),  null, null);
                     }                    
                 }, subject, null, null, null);
                 results.value.push({


### PR DESCRIPTION
Renamed the `qname()` function to `qnameToIri()` to better reflect what the function does. Added an inverse to `qnameToIri()` called `iriToQname()` to the rdfStore.

Also moved the copy to clipboard to helper functions for reusability.

Will take this PR out of draft once #80 is merged.