### PR TITLE
Label language priority order

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -190,3 +190,9 @@ export interface PredCellProps {
     description?: string;
     explanation?: string;
 };
+
+export type languageLabel = {
+    value: string;
+    language?: string;
+    priority: number;
+};

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -52,3 +52,24 @@ export const sortByTitle = <T extends {title?: string; iri: string;}>(a: T, b: T
         return a.iri.localeCompare(b.iri);
     }
 };
+
+/**
+ * Returns an integer priority based on an RDF literal's language tag
+ * 
+ * Priority order is: 1. `@en`, 2. `@en-*`, 3. No language tag, 4. Other language tags.
+ * 
+ * @param language 
+ * @returns the priority order as an integer
+ */
+export function getLanguagePriority(language: string): number {
+    // get browser language, return 0
+    if (language === "en") {
+        return 1;
+    } else if (/en-.+/.test(language)) { // en-us, en-gb, etc.
+        return 2;
+    } else if (language === "") {
+        return 3;
+    } else {
+        return 4;
+    }
+}

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -6,7 +6,7 @@ import { useUiStore } from "@/stores/ui";
 import { useRdfStore } from "@/composables/rdfStore";
 import { useApiRequest } from "@/composables/api";
 import type { WKTResult } from "@/components/MapClient.d";
-import { apiBaseUrlConfigKey, conceptPerPageConfigKey, enableScoresKey, type ListItem, type AnnotatedQuad, type Breadcrumb, type Concept, type PrezFlavour, type Profile, type ListItemExtra, type ListItemSortable } from "@/types";
+import { apiBaseUrlConfigKey, conceptPerPageConfigKey, enableScoresKey, type ListItem, type AnnotatedQuad, type Breadcrumb, type Concept, type PrezFlavour, type Profile, type ListItemExtra, type ListItemSortable, type languageLabel } from "@/types";
 import PropTable from "@/components/proptable/PropTable.vue";
 import ConceptComponent from "@/components/ConceptComponent.vue";
 import AdvancedSearch from "@/components/search/AdvancedSearch.vue";
@@ -16,7 +16,7 @@ import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 import MapClient from "@/components/MapClient.vue";
 import SortableTabularList from "@/components/SortableTabularList.vue";
 import LoadingMessage from "@/components/LoadingMessage.vue";
-import { ensureProfiles, titleCase, sortByTitle } from "@/util/helpers";
+import { ensureProfiles, titleCase, sortByTitle, getLanguagePriority } from "@/util/helpers";
 import ScoreWidget from "@/components/scores/ScoreWidget.vue";
 
 const { namedNode } = DataFactory;
@@ -142,12 +142,19 @@ function getProperties() {
     // get label & description predicates
     const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
     const descPredicates = defaultProfile.value!.descriptionPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
-    hiddenPredicates.value.push(...[...labelPredicates, ...descPredicates]);
+    hiddenPredicates.value.push(...descPredicates);
+
+    const labels: languageLabel[] = [];
 
     // get attributes for item object, fill out properties
     store.value.forEach(q => {
         if (labelPredicates.includes(q.predicate.value)) {
-            item.value.title = q.object.value;
+            let language = (q.object as Literal).language;
+            labels.push({
+                value: q.object.value,
+                language: language || undefined,
+                priority: getLanguagePriority(language)
+            });
         } else if (descPredicates.includes(q.predicate.value)) {
             item.value.description = q.object.value;
         } else if (DEFAULT_CHILDREN_PREDICATES.includes(q.predicate.value)) {
@@ -189,6 +196,16 @@ function getProperties() {
             findBlankNodes(q, store.value, recursionCounter);
         }
     }, subject, null, null, null);
+
+    // sort labels by language priority
+    labels.sort((a, b) => a.priority - b.priority);
+
+    // set title to highest priority language tag
+    item.value.title = labels.length > 0 ? labels[0].value : undefined;
+
+    if (labels.length === 1) { // hide label property in table if there is only one label
+        hiddenPredicates.value.push(...labelPredicates);
+    }
 
     if (hasScores.value) {
         getScores();
@@ -324,9 +341,16 @@ function getChildren() {
                 extras: {}
             };
 
+            const labels: languageLabel[] = [];
+
             store.value.forEach(q => {
                 if (labelPredicates.includes(q.predicate.value)) {
-                    child.title = q.object.value;
+                    let language = (q.object as Literal).language;
+                    labels.push({
+                        value: q.object.value,
+                        language: language || undefined,
+                        priority: getLanguagePriority(language)
+                    });
                 } else if (q.predicate.value === qnameToIri("prez:link")) {
                     child.link = q.object.value;
                 } else if (q.predicate.value === qnameToIri("a")) {
@@ -353,6 +377,12 @@ function getChildren() {
                 } 
             }, obj, null, null, null);
 
+            // sort labels by language priority
+            labels.sort((a, b) => a.priority - b.priority);
+
+            // set title to highest priority language tag
+            child.title = labels.length > 0 ? labels[0].value : undefined;
+
             children.value.push(child);
         }, namedNode(item.value.iri), namedNode(childrenPredicate.value), null);
 
@@ -374,9 +404,17 @@ function getAllConcepts() {
             childrenCount: 0,
             children: []
         };
+
+        const labels: languageLabel[] = [];
+        
         store.value.forEach(q => {
             if (q.predicate.value === qnameToIri("skos:prefLabel")) {
-                c.title = q.object.value;
+                let language = (q.object as Literal).language;
+                labels.push({
+                    value: q.object.value,
+                    language: language || undefined,
+                    priority: getLanguagePriority(language)
+                });
             } else if (q.predicate.value === qnameToIri("prez:link")) {
                 c.link = q.object.value;
             } else if (q.predicate.value === qnameToIri("skos:narrower")) {
@@ -385,6 +423,11 @@ function getAllConcepts() {
                 c.broader = q.object.value;
             }
         }, subject, null, null, null);
+        // sort labels by language priority
+        labels.sort((a, b) => a.priority - b.priority);
+
+        // set title to highest priority language tag
+        c.title = labels.length > 0 ? labels[0].value : "";
         c.childrenCount = c.narrower!.length;
         conceptArray.push(c);
     }, namedNode(qnameToIri("skos:inScheme")), namedNode(item.value.iri), null);
@@ -438,9 +481,15 @@ async function getTopConcepts(page: number = 1) {
                 children: [],
                 color: "",
             };
+            const labels: languageLabel[] = [];
             conceptStore.value.forEach(q => {
                 if (q.predicate.value === conceptQnameToIri("skos:prefLabel")) {
-                    c.title = q.object.value;
+                    let language = (q.object as Literal).language;
+                    labels.push({
+                        value: q.object.value,
+                        language: language || undefined,
+                        priority: getLanguagePriority(language)
+                    });
                 } else if (q.predicate.value === conceptQnameToIri("prez:link")) {
                     c.link = q.object.value;
                 } else if (q.predicate.value === conceptQnameToIri("prez:childrenCount")) {
@@ -449,6 +498,11 @@ async function getTopConcepts(page: number = 1) {
                     c.color = q.object.value;
                 }
             }, object, null, null, null);
+            // sort labels by language priority
+            labels.sort((a, b) => a.priority - b.priority);
+
+            // set title to highest priority language tag
+            c.title = labels.length > 0 ? labels[0].value : "";
             concepts.value.push(c);
         }, namedNode(item.value.iri), namedNode(conceptQnameToIri("skos:hasTopConcept")), null);
 
@@ -485,9 +539,15 @@ async function getNarrowers({ iriPath, link, page = 1 }: { iriPath: string, link
                 children: [],
                 color: "",
             };
+            const labels: languageLabel[] = [];
             conceptStore.value.forEach(q => {
                 if (q.predicate.value === conceptQnameToIri("skos:prefLabel")) {
-                    c.title = q.object.value;
+                    let language = (q.object as Literal).language;
+                    labels.push({
+                        value: q.object.value,
+                        language: language || undefined,
+                        priority: getLanguagePriority(language)
+                    });
                 } else if (q.predicate.value === conceptQnameToIri("prez:link")) {
                     c.link = q.object.value;
                 } else if (q.predicate.value === conceptQnameToIri("prez:childrenCount")) {
@@ -496,6 +556,11 @@ async function getNarrowers({ iriPath, link, page = 1 }: { iriPath: string, link
                     c.color = q.object.value;
                 }
             }, object, null, null, null);
+            // sort labels by language priority
+            labels.sort((a, b) => a.priority - b.priority);
+
+            // set title to highest priority language tag
+            c.title = labels.length > 0 ? labels[0].value : "";
             parent!.children.push(c);
         }, namedNode(parent!.iri), namedNode(conceptQnameToIri("skos:narrower")), null);
 


### PR DESCRIPTION
Labels are now set in order of language priority in the following order:

1. `@en`
2. `@en-*` (e.g. `@en-us`, `@en-gb`, etc.)
3. no language tag
4. Other language tags

Resolves #103.