### PR TITLE
Alternate profiles page fix

### DIFF
--- a/src/components/ProfilesTable.vue
+++ b/src/components/ProfilesTable.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 import { useUiStore } from "@/stores/ui";
+import { ALT_PROFILE_URI } from "@/util/consts";
 
 const mediatypeNames: {[key: string]: string} = {
     "text/html": "HTML",
@@ -14,20 +15,22 @@ const mediatypeNames: {[key: string]: string} = {
 
 const ui = useUiStore();
 
-const defaultToken = computed(() => {
-    const defaultProfile = ui.rightNavConfig.profiles!.find(p => p.default);
-    if (defaultProfile === undefined) {
-        throw new TypeError("A default profile must exist.");
-    }
-    return defaultProfile.token;
-});
+// const defaultToken = computed(() => {
+//     const defaultProfile = ui.rightNavConfig.profiles!.find(p => p.default);
+//     if (defaultProfile === undefined) {
+//         throw new TypeError("A default profile must exist.");
+//     }
+//     return defaultProfile.token;
+// });
 
 const orderedProfiles = computed(() => {
     const includedProfiles = ui.rightNavConfig.profiles!.map(prof => prof.token);
+    // sort profiles - alphabetical, alternates profile last
     return Object.values(ui.profiles)
         .filter(prof => includedProfiles.includes(prof.token))
-        .sort((a, b) => Number(b.token === defaultToken.value) - Number(a.token === defaultToken.value))
-        .sort((a, b) => Number(a.namespace === "http://www.w3.org/ns/dx/conneg/altr-ext#alt-profile") - Number(b.namespace === "http://www.w3.org/ns/dx/conneg/altr-ext#alt-profile"));
+        // .sort((a, b) => Number(b.token === defaultToken.value) - Number(a.token === defaultToken.value))
+        .sort((a, b) => a.title.localeCompare(b.title))
+        .sort((a, b) => Number(a.namespace === ALT_PROFILE_URI) - Number(b.namespace === ALT_PROFILE_URI));
 });
 </script>
 
@@ -46,7 +49,7 @@ const orderedProfiles = computed(() => {
                 <RouterLink :to="`${ui.rightNavConfig.currentUrl}?_profile=${profile.token}`" title="Get profile representation">
                     {{ profile.token }}
                 </RouterLink>
-                <span v-if="(profile.token === defaultToken)" class="badge" title="This is the default profile for this endpoint">default</span>
+                <!-- <span v-if="(profile.token === defaultToken)" class="badge" title="This is the default profile for this endpoint">default</span> -->
             </td>
             <td><RouterLink :to="`/profiles/${profile.token}`" title="Go to profile page">{{ profile.title }}</RouterLink></td>
             <td>

--- a/src/components/search/CatPrezSearchMap.vue
+++ b/src/components/search/CatPrezSearchMap.vue
@@ -114,8 +114,8 @@ function handleMapSelectionChange(selectedCoords: Coords, shapeType: ShapeTypes)
 async function getCatalogs() {
     const { data: catalogData, profiles: catalogProfiles } = await catalogApiGetRequest("/c/catalogs");
     if (catalogData && catalogProfiles.length > 0 && !catalogError.value) {
-        const defaultProfile = ui.profiles[catalogProfiles.find(p => p.default)!.uri];
-        const labelPredicates = defaultProfile.labelPredicates.length > 0 ? defaultProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
+        const currentProfile = ui.profiles[catalogProfiles.find(p => p.current)!.uri];
+        const labelPredicates = currentProfile.labelPredicates.length > 0 ? currentProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
 
         parseIntoStore(catalogData);
 

--- a/src/components/search/SpacePrezSearch.vue
+++ b/src/components/search/SpacePrezSearch.vue
@@ -68,8 +68,8 @@ onMounted(async () => {
     const { data: datasetData, profiles: datasetProfiles } = await datasetApiGetRequest("/s/datasets");
 
     if (datasetData && datasetProfiles.length > 0 && !datasetError.value) {
-        const defaultProfile = ui.profiles[datasetProfiles.find(p => p.default)!.uri];
-        const labelPredicates = defaultProfile.labelPredicates.length > 0 ? defaultProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
+        const currentProfile = ui.profiles[datasetProfiles.find(p => p.current)!.uri];
+        const labelPredicates = currentProfile.labelPredicates.length > 0 ? currentProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
 
         parseIntoStore(datasetData);
 

--- a/src/components/search/SpacePrezSearchMap.vue
+++ b/src/components/search/SpacePrezSearchMap.vue
@@ -161,8 +161,8 @@ function handleMapSelectionChange(selectedCoords: Coords, shapeType: ShapeTypes)
 async function getDatasets() {
     const { data, profiles } = await datasetApiGetRequest("/s/datasets");
     if (data && profiles.length > 0 && !datasetError.value) {
-        const defaultProfile = ui.profiles[profiles.find(p => p.default)!.uri];
-        const labelPredicates = defaultProfile.labelPredicates.length > 0 ? defaultProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
+        const currentProfile = ui.profiles[profiles.find(p => p.current)!.uri];
+        const labelPredicates = currentProfile.labelPredicates.length > 0 ? currentProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
 
         parseIntoStore(data);
 
@@ -198,8 +198,8 @@ async function getDatasets() {
             }
         });
 
-        const fcDefaultProfile = ui.profiles[fcProfiles.find(p => p.default)!.uri];
-        const fcLabelPredicates = fcDefaultProfile.labelPredicates.length > 0 ? fcDefaultProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
+        const fcCurrentProfile = ui.profiles[fcProfiles.find(p => p.current)!.uri];
+        const fcLabelPredicates = fcCurrentProfile.labelPredicates.length > 0 ? fcCurrentProfile.labelPredicates : DEFAULT_LABEL_PREDICATES;
 
         store.value.forSubjects(subject => { // get datasets
             store.value.forObjects(object => { // get fcs per dataset

--- a/src/composables/api.ts
+++ b/src/composables/api.ts
@@ -65,6 +65,7 @@ function getProfilesFromHeaders(link: string): ProfileHeader[] {
     links.filter(l => l.rel === "type").forEach(l => {
         profileObj[l.anchor] = {
             default: false,
+            current: false,
             token: l.token,
             mediatypes: [],
             title: l.title,
@@ -73,8 +74,13 @@ function getProfilesFromHeaders(link: string): ProfileHeader[] {
         };
     });
 
-    const defaultProfile = links.find(l => l.rel === "self")!;
-    profileObj[defaultProfile.profile].default = true;
+    // find current - either use rel="self" or rel="profile"
+    const currentProfile = links.find(l => l.rel === "self")!;
+    profileObj[currentProfile.profile].current = true;
+
+    // find default - no way to get default for now - use rel="canonical" according to https://www.w3.org/TR/dx-prof-conneg/#http-listprofiles ?
+    // const defaultProfile = links.find(l => l.rel === "self")!;
+    // profileObj[defaultProfile.profile].default = true;
 
     links.filter(l => l.rel === "alternate").forEach(l => {
         if (!profileObj[l.profile].mediatypes.map(m => m.mediatype).includes(l.type)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface Mediatype {
 
 export interface ProfileHeader {
     default: boolean;
+    current: boolean;
     uri: string;
     token: string;
     title: string;

--- a/src/util/consts.ts
+++ b/src/util/consts.ts
@@ -1,0 +1,2 @@
+export const ALT_PROFILE_CURIE = "altr-ext:alt-profile";
+export const ALT_PROFILE_URI = "http://www.w3.org/ns/dx/conneg/altr-ext#alt-profile";

--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -15,6 +15,7 @@ import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
 import SortableTabularList from "@/components/SortableTabularList.vue";
 import LoadingMessage from "@/components/LoadingMessage.vue";
 import { ensureProfiles, sortByTitle, getLanguagePriority } from "@/util/helpers";
+import { ALT_PROFILE_CURIE } from "@/util/consts";
 
 const { namedNode, literal } = DataFactory;
 
@@ -37,7 +38,6 @@ const TOP_LEVEL_TYPES = [
     qnameToIri("prez:SpacePrezProfile"),
     qnameToIri("prez:VocPrezProfile"),
 ];
-const ALT_PROFILES_TOKEN = "lt-prfl:alt-profile";
 
 // const parent = ref<ListItem>({} as ListItem); // might need to store parent info (dataset & feature collection)
 const items = ref<ListItemExtra[]>([]);
@@ -48,7 +48,7 @@ const itemType = ref({
 const count = ref(0);
 const isAltView = ref(false);
 const flavour = ref<PrezFlavour | null>(null);
-const defaultProfile = ref<Profile | null>(null);
+const currentProfile = ref<Profile | null>(null);
 const searchEnabled = ref(false);
 const searchDefaults = ref<{[key: string]: string}>({});
 const childrenConfig = ref({
@@ -124,7 +124,7 @@ function getBreadcrumbs(): Breadcrumb[] {
         uri: string;
     }[] = [];
 
-    const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+    const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
     const pathSegments = route.path.split("/").slice(1);
 
     pathSegments.forEach((id, index) => {
@@ -195,7 +195,7 @@ function getBreadcrumbs(): Breadcrumb[] {
     });
 
     if (isAltView.value) {
-        crumbs.push({ name: "Alternate Profiles", url: `${route.path}?_profile=${ALT_PROFILES_TOKEN}` });
+        crumbs.push({ name: "Alternate Profiles", url: `${route.path}?_profile=${ALT_PROFILE_CURIE}` });
     }
     return crumbs;
 }
@@ -214,8 +214,8 @@ function getProperties() {
     }
 
     // get label & description predicates
-    const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
-    const descPredicates = defaultProfile.value!.descriptionPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
+    const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+    const descPredicates = currentProfile.value!.descriptionPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
 
     // fill out item list & handle vocprez items
     nodeList.forEach(member => {
@@ -316,7 +316,7 @@ onBeforeMount(() => {
     }
 
     // check if alt profile & no mediatype, then show alt profiles page
-    if (route.query._profile === ALT_PROFILES_TOKEN && !route.query._mediatype) {
+    if (route.query._profile === ALT_PROFILE_CURIE && !route.query._mediatype) {
         isAltView.value = true;
     }
 
@@ -328,17 +328,29 @@ onBeforeMount(() => {
 onMounted(async () => {
     loading.value = true;
 
-    let fullPath = Object.keys(route.query).length > 0 ? (route.query.per_page ? route.fullPath : route.fullPath + `&per_page=${perPage.value}`) : route.path + `?per_page=${perPage.value}`;
+    let fullPath = "";
+    if (Object.keys(route.query).length > 0) {
+        fullPath = route.fullPath;
+        if (isAltView.value) { // remove alt profile qsa to get title for breadcrumbs - already have profile info in pinia/link headers
+            fullPath = fullPath.replace(`_profile=${ALT_PROFILE_CURIE}`, "");
+        }
+
+        if (!route.query.per_page) {
+            fullPath += `&per_page=${perPage.value}`;
+        }
+    } else {
+        fullPath = `${route.path}?per_page=${perPage.value}`;
+    }
 
     await ensureProfiles(); // wait for profiles to be set in Pinia
 
     const { data, profiles } = await apiGetRequest(fullPath);
     if (data && profiles.length > 0 && !error.value) {
-        defaultProfile.value = ui.profiles[profiles.find(p => p.default)!.uri];
+        currentProfile.value = ui.profiles[profiles.find(p => p.current)!.uri];
             
         // if specify mediatype, or profile is not default or alt, redirect to API
         if ((route.query && route.query._profile) &&
-            (route.query._mediatype || ![defaultProfile.value.token, ALT_PROFILES_TOKEN].includes(route.query._profile as string))) {
+            (route.query._mediatype || ![currentProfile.value.token, ALT_PROFILE_CURIE].includes(route.query._profile as string))) {
                 window.location.replace(`${apiBaseUrl}${route.path}?_profile=${route.query._profile}${route.query._mediatype ? `&_mediatype=${route.query._mediatype}` : ""}`);
         }
 

--- a/src/views/ObjectView.vue
+++ b/src/views/ObjectView.vue
@@ -40,7 +40,7 @@ type objectItem = {
     }[];
 };
 
-const defaultProfile = ref<Profile | null>(null);
+const currentProfile = ref<Profile | null>(null);
 const item = ref<objectItem>({} as objectItem);
 const links = ref<string[]>([]);
 
@@ -62,9 +62,9 @@ onMounted(async () => {
                     links: [],
                     types: []
                 };
-                defaultProfile.value = ui.profiles[profiles.find(p => p.default)!.uri];
-                const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
-                const descPredicates = defaultProfile.value!.descriptionPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
+                currentProfile.value = ui.profiles[profiles.find(p => p.current)!.uri];
+                const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+                const descPredicates = currentProfile.value!.descriptionPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
 
                 store.value.forEach(q => {
                     if (labelPredicates.includes(q.predicate.value)) {

--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -18,6 +18,7 @@ import SortableTabularList from "@/components/SortableTabularList.vue";
 import LoadingMessage from "@/components/LoadingMessage.vue";
 import { ensureProfiles, titleCase, sortByTitle, getLanguagePriority } from "@/util/helpers";
 import ScoreWidget from "@/components/scores/ScoreWidget.vue";
+import { ALT_PROFILE_CURIE } from "@/util/consts";
 
 const { namedNode, literal } = DataFactory;
 
@@ -37,7 +38,6 @@ const DEFAULT_DESC_PREDICATES = [qnameToIri("dcterms:description")];
 const DEFAULT_GEO_PREDICATES = [qnameToIri("geo:hasBoundingBox"), qnameToIri("geo:hasGeometry")];
 const DEFAULT_CHILDREN_PREDICATES = [qnameToIri("rdfs:member"), qnameToIri("skos:member"), qnameToIri("dcterms:hasPart")];
 const RECURSION_LIMIT = 5; // limit on recursive search of blank nodes
-const ALT_PROFILES_TOKEN = "lt-prfl:alt-profile";
 
 const item = ref<ListItem>({} as ListItem);
 const children = ref<ListItemExtra[]>([]);
@@ -60,7 +60,7 @@ const hiddenPredicates = ref<string[]>([
     qnameToIri("prez:link"),
     "https://linked.data.gov.au/def/scores/hasScore"
 ]);
-const defaultProfile = ref<Profile | null>(null);
+const currentProfile = ref<Profile | null>(null);
 const childrenConfig = ref({
     showChildren: false,
     childrenTitle: "",
@@ -140,8 +140,8 @@ function getProperties() {
     };
 
     // get label & description predicates
-    const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
-    const descPredicates = defaultProfile.value!.descriptionPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
+    const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+    const descPredicates = currentProfile.value!.descriptionPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_DESC_PREDICATES;
     hiddenPredicates.value.push(...descPredicates);
 
     const labels: languageLabel[] = [];
@@ -251,7 +251,7 @@ function getBreadcrumbs(): Breadcrumb[] {
         uri: string;
     }[] = [];
 
-    const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+    const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
     const pathSegments = route.path.split("/").slice(1, -1);
 
     pathSegments.forEach((id, index) => {
@@ -339,7 +339,7 @@ function getBreadcrumbs(): Breadcrumb[] {
 
     crumbs.push({ name: item.value.title || item.value.iri, url: route.path });
     if (isAltView.value) {
-        crumbs.push({ name: "Alternate Profiles", url: `${route.path}?_profile=${ALT_PROFILES_TOKEN}` });
+        crumbs.push({ name: "Alternate Profiles", url: `${route.path}?_profile=${ALT_PROFILE_CURIE}` });
     }
     return crumbs;
 }
@@ -362,7 +362,7 @@ function getChildren() {
             getTopConcepts();
         }
     } else {
-        const labelPredicates = defaultProfile.value!.labelPredicates.length > 0 ? defaultProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
+        const labelPredicates = currentProfile.value!.labelPredicates.length > 0 ? currentProfile.value!.labelPredicates : DEFAULT_LABEL_PREDICATES;
 
         store.value.forObjects((obj) => {
             let child: ListItemExtra = {
@@ -703,7 +703,7 @@ onBeforeMount(() => {
     }
 
     // check if alt profile & no mediatype, then show alt profiles page
-    if (route.query._profile === ALT_PROFILES_TOKEN && !route.query._mediatype) {
+    if (route.query._profile === ALT_PROFILE_CURIE && !route.query._mediatype) {
         isAltView.value = true;
     }
 });
@@ -721,15 +721,27 @@ onMounted(async () => {
         }
     }
 
-    const { data, profiles } = await apiGetRequest(hasFewChildren.value ? `${route.path}/all${window.location.search}` : route.fullPath);
+    let fullPath = "";
+    if (hasFewChildren.value) {
+        fullPath = `${route.path}/all${window.location.search}`;
+    } else {
+        fullPath = route.fullPath;
+    }
+    if (Object.keys(route.query).length > 0) {
+        if (isAltView.value) { // remove alt profile qsa to get title for breadcrumbs - already have profile info in pinia/link headers
+            fullPath = fullPath.replace(`_profile=${ALT_PROFILE_CURIE}`, "");
+        }
+    }
+
+    const { data, profiles } = await apiGetRequest(fullPath);
 
     if (data && profiles.length > 0 && !error.value) {
         // find the current/default profile
-        defaultProfile.value = ui.profiles[profiles.find(p => p.default)!.uri];
+        currentProfile.value = ui.profiles[profiles.find(p => p.current)!.uri];
         
         // if specify mediatype, or profile is not default or alt, redirect to API
         if ((route.query && route.query._profile) &&
-            (route.query._mediatype || ![defaultProfile.value.token, ALT_PROFILES_TOKEN].includes(route.query._profile as string))) {
+            (route.query._mediatype || ![currentProfile.value.token, ALT_PROFILE_CURIE].includes(route.query._profile as string))) {
                 window.location.replace(`${apiBaseUrl}${route.path}?_profile=${route.query._profile}${route.query._mediatype ? `&_mediatype=${route.query._mediatype}` : ""}`);
         }
 


### PR DESCRIPTION
This fixes the blank Alternate Profiles page, which was an error caused by the frontend requesting the full path containing `_profile=altr-ext:alt-profile`. This doesn't return data required by the breadcrumbs. Now the frontend removes `_profile=altr-ext:alt-profile` in order to get title from the data for the breadcrumbs.

The currently used profile now displays "current" on the right nav instead of "default". Ordering of the profiles is now consistent, sorting alphabetically first and Alternates Profile at the bottom.

The mediatype quick links on the right nav now go to the API URL directly.

Resolves #108, resolves #104, resolves #102.