### PR TITLE
Updated index file path pattern to cater for Vite v4 breaking change

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INDEX_FILE=/app/assets/index.*.js;
+INDEX_FILE=/app/assets/index-*.js;
 
 grep "=" .env | while read -r line; do # loop over VITE_ env vars
     left=`echo $line | awk -F "=" '{print $1}'`; # env var name


### PR DESCRIPTION
Fixed a breaking change with migrating from Vite v3 to v4 where the built `index.js` filename pattern was changed from `index.*.js` to `index-*.js`.