### PR TITLE
Moved setting concept broaders into its own loop to ensure ordering

### DIFF
--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -407,13 +407,17 @@ async function getAllConcepts() {
     }, {});
 
     let conceptsList: Concept[] = [];
+
+    // set broader first
     conceptArray.forEach(c => {
         if (c.narrower!.length > 0) {
             c.narrower!.forEach(n => {
                 conceptArray[indexMap[n]].broader = c.iri;
             });
         }
+    });
 
+    conceptArray.forEach(c => {
         if (topConcepts.includes(c.iri)) {
             conceptsList.push(c);
             return;


### PR DESCRIPTION
Moved the logic for setting concepts broader property within a concept hierarchy outside the current loop to ensure broaders are set first. This fixes an issue causing some concepts to not render if broader wasn't set early enough.

Resolves #111.