### PR TITLE
Removed second call to configByBaseClass() in PropTableView

### DIFF
--- a/src/views/PropTableView.vue
+++ b/src/views/PropTableView.vue
@@ -143,7 +143,6 @@ async function getProperties() {
             childrenPredicate.value = q.predicate.value;
             hiddenPredicates.value.push(q.predicate.value);
         } else if (q.predicate.value === qnameToIri("a")) {
-            configByBaseClass(q.object.value); // might not be needed anymore with the /object changes
             const typeLabel = getLabel(q.object.value, store.value);
             const typeDesc = getDescription(q.object.value, store.value);
             const typeQname = iriToQname(q.object.value);


### PR DESCRIPTION
Removed a second call to `configByBaseClass()` in `PropTableView.vue` as it was overriding the base class which was set earlier by regex matching the URL path. This caused an issue where the concept hierarchy wasn't being rendered for vocabs that had more than one type.

Resolves #124.