### PR TITLE
Fix for list pages not reading rdfs:member & /object page links not rendering properly

### DIFF
--- a/src/views/ItemListView.vue
+++ b/src/views/ItemListView.vue
@@ -7,7 +7,7 @@ import { useRdfStore } from "@/composables/rdfStore";
 import { useApiRequest } from "@/composables/api";
 import { apiBaseUrlConfigKey, perPageConfigKey, type Breadcrumb, type PrezFlavour, type Profile, type ListItemExtra, type ListItemSortable } from "@/types";
 import { getPrezSystemLabel } from "@/util/prezSystemLabelMapping";
-import { sortByTitle, getBaseClassFromLink, ensureAnnotationPredicates, getLabel, getDescription } from "@/util/helpers";
+import { sortByTitle, getBaseClassFromLink, ensureAnnotationPredicates, getLabel, getDescription, getObjects } from "@/util/helpers";
 import { ALT_PROFILE_CURIE } from "@/util/consts";
 import ItemList from "@/components/ItemList.vue";
 import ProfilesTable from "@/components/ProfilesTable.vue";
@@ -230,8 +230,7 @@ function getProperties() {
 
         // for /c/profiles, etc. need to look for prez:CatPrezProfile, etc.
     } else {
-        // nodeList = store.value.getObjects(countQuad.subject, namedNode(qnameToIri("rdfs:member")), null);
-        nodeList = store.value.getObjects(countQuad.subject, namedNode(qnameToIri("dcterms:hasPart")), null); // TODO: need to cater for rdfs:member & dcterms:hasPart
+        nodeList = getObjects(countQuad.subject.value, [qnameToIri("rdfs:member"), qnameToIri("dcterms:hasPart")], store.value);
         const containerBaseClass = iriToQname(getBaseClassFromLink(route.path.slice(0, route.path.lastIndexOf("/"))).iri);
         searchConfig.value = {
             containerUri: countQuad.subject.value,

--- a/src/views/ObjectView.vue
+++ b/src/views/ObjectView.vue
@@ -66,6 +66,8 @@ onMounted(async () => {
                 item.value.title = getLabel(subject.value, store.value);
                 item.value.description = getDescription(subject.value, store.value);
 
+                const id = store.value.getObjects(subject, namedNode(qnameToIri("dcterms:identifier")), null)[0].value;
+
                 store.value.forEach(q => {
                     if (q.predicate.value === qnameToIri("a")) {
                         item.value.types.push({
@@ -73,7 +75,7 @@ onMounted(async () => {
                             title: getLabel(q.object.value, store.value),
                         });
                     } else if (q.predicate.value === qnameToIri("prez:link")) {
-                        const parentIds = store.value.getQuads(null, namedNode(qnameToIri("dcterms:identifier")), null, null).filter(q1 => q.object.value.includes(q1.object.value));
+                        const parentIds = store.value.getQuads(null, namedNode(qnameToIri("dcterms:identifier")), null, null).filter(q1 => q1.object.value !== id && q.object.value.includes(q1.object.value));
                         
                         if (parentIds.length === 1) {
                             let parentIri = parentIds[0].subject.value;


### PR DESCRIPTION
Some intermediate code was left behind while transitioning to using a new helper function `getObjects()` which accepts a list of multiple predicates for ease of use. Currently, feature collections & features are not rendered on list pages. This is now fixed by using the new `getObjects()` function.

Also, objects on the `/object` page were not rendering links correctly if they had multiple links. The current logic was that links for parent objects may have included the `prez:link` for the focus object. This is now fixed with an extra filter condition.