### PR TITLE
Don't auto-commit and tag when setting version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Update project version
         run: |
-          npm version ${{ steps.version.outputs.VALUE }}
+          npm version ${{ steps.version.outputs.VALUE }} ----no-git-tag-version
           git add package.json
           git commit -m "chore: release ${{ steps.version.outputs.VALUE }}"
           git push

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Update project version
         run: |
-          npm version ${{ steps.version.outputs.VALUE }} ----no-git-tag-version
+          npm version ${{ steps.version.outputs.VALUE }} --no-git-tag-version
           git add package.json
           git commit -m "chore: release ${{ steps.version.outputs.VALUE }}"
           git push


### PR DESCRIPTION
Running `npm version` by default auto commits and tags it with the version. Disable this as it's quite a surprising default.