### PR TITLE
Base URL entrypoint fix

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -19,7 +19,9 @@ if (declare -p "VITE_BASE_URL" &>/dev/null)
 then
     sed -i "s|BASE_URL = \"/\"|BASE_URL = \"$VITE_BASE_URL\"|g" /app/index.html
     sed -i "s|/@BASE_URL@/|$VITE_BASE_URL|g" /app/index.html ${INDEX_FILE}
-    cp /app/index.html /app/404.html
+else
+    sed -i "s|/@BASE_URL@/|/|g" /app/index.html ${INDEX_FILE}
 fi
+cp /app/index.html /app/404.html
 
 nginx -g 'daemon off;';

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,7 +16,7 @@ http {
 
         access_log /var/log/nginx/access.log;
         gzip on;
-        gzip_types text/html application/javascript application/json text/css;
+        gzip_types application/javascript application/json text/css;
         root /app;
         index index.html;
         


### PR DESCRIPTION
Fixed an issue where docker containers not specifying a `VITE_BASE_URL` env var doesn't replace `@BASE_URL@` to / in `index.html`.