### PR TITLE
Fixed an issue with Storybook & component types with PNPM

### DIFF
--- a/prez-components/src/components/PrezUIConcept.vue
+++ b/prez-components/src/components/PrezUIConcept.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
 import { ref } from "vue";
-import type { Concept } from "prez-lib";
 import Button from "primevue/button";
+import type { PrezUIConceptProps } from "../types";
 import PrezUINode from "./PrezUINode.vue";
 
-const props = defineProps<Concept>();
+const props = defineProps<PrezUIConceptProps>();
 
 const open = ref(false);
 

--- a/prez-components/src/components/PrezUIObjectTable.vue
+++ b/prez-components/src/components/PrezUIObjectTable.vue
@@ -79,10 +79,10 @@ const placeholderProperties = [
             <template #body="slotProps">
                 <Skeleton v-if="props.loading" width="30rem" class="mb-2"></Skeleton>
                 <template v-else>
-                    <template v-if="slotProps.data.predicate.value === 'https://prez.dev/concepts'">
+                    <template v-if="props.data?.concepts && slotProps.data.predicate.value === 'https://prez.dev/concepts'">
                         <PrezUIConceptHierarchy :concepts="slotProps.data.objects" />
                     </template>
-                    <template v-else-if="slotProps.data.predicate.value === 'https://prez.dev/members'">
+                    <template v-else-if="props.data?.members && slotProps.data.predicate.value === 'https://prez.dev/members'">
                         <RouterLink v-for="member in slotProps.data.objects" :to="member.value">
                             <Button size="small" outlined>Members</Button>
                         </RouterLink>

--- a/prez-components/src/stories/PrezUIItemList.stories.ts
+++ b/prez-components/src/stories/PrezUIItemList.stories.ts
@@ -8,7 +8,8 @@ const meta = {
     component: PrezUIItemList,
     tags: ["autodocs"],
     argTypes: {
-        items: { description: "The list of items" },
+        data: { description: "The list of items" },
+        loading: { description: "Loading state" },
     },
 } satisfies Meta<typeof PrezUIItemList>;
 
@@ -38,7 +39,7 @@ const publisher = node({
 
 export const Default: Story = {
     args: {
-        items: [
+        data: [
             {
                 focusNode: {
                     ...node({

--- a/prez-components/src/stories/PrezUIObjectTable.stories.ts
+++ b/prez-components/src/stories/PrezUIObjectTable.stories.ts
@@ -8,8 +8,9 @@ const meta = {
     component: PrezUIObjectTable,
     tags: ["autodocs"],
     argTypes: {
-        properties: { description: "The list of properties" },
-        members: { description: "A list of member links" }
+        data: { description: "The list of properties" },
+        hideHidden: { description: "Hides hidden properties" },
+        loading: { description: "Loading state" },
     },
 } satisfies Meta<typeof PrezUIObjectTable>;
 
@@ -39,20 +40,22 @@ const publisher = node({
 
 export const Default: Story = {
     args: {
-        properties: {
-            [creator.value]: {
-                predicate: creator,
-                objects: [literal("object 1")]
-            },
-            [issued.value]: {
-                predicate: issued,
-                objects: [literal("object 2")]
-            },
-            [publisher.value]: {
-                predicate: publisher,
-                objects: [literal("object 3")]
-            },
-            // some blank node data to show nested tables
+        data: {
+            properties: {
+                [creator.value]: {
+                    predicate: creator,
+                    objects: [literal("object 1")]
+                },
+                [issued.value]: {
+                    predicate: issued,
+                    objects: [literal("object 2")]
+                },
+                [publisher.value]: {
+                    predicate: publisher,
+                    objects: [literal("object 3")]
+                },
+                // some blank node data to show nested tables
+            }
         }
     },
 }

--- a/prez-components/src/types.ts
+++ b/prez-components/src/types.ts
@@ -43,3 +43,5 @@ export interface PrezUIObjectTableProps {
 //     items: PrezItem[];
 //     headers?: PrezNode[];
 // };
+
+export interface PrezUIConceptProps extends Concept {};


### PR DESCRIPTION
Re-exported the `Concept` type for the `PrezUIConcept` component's prop type as a workaround for Storybook.

Also updated stories to the latest type changes.