### PR TITLE
Allows the use of the Prez /sparql endpoint using POST method

### DIFF
--- a/src/components/search/CatPrezSearchMap.vue
+++ b/src/components/search/CatPrezSearchMap.vue
@@ -41,8 +41,8 @@ type SparqlBinding = {
 const apiBaseUrl = inject(apiBaseUrlConfigKey) as string;
 
 const { loading: catalogLoading, error: catalogError, apiGetRequest: catalogApiGetRequest } = useApiRequest();
-const { loading: themesLoading, error: themesError, sparqlGetRequest: themesSparqlGetRequest } = useSparqlRequest();
-const { loading: searchLoading, error: searchError, sparqlGetRequest: searchSparqlGetRequest } = useSparqlRequest();
+const { loading: themesLoading, error: themesError, sparqlGetRequest: themesSparqlGetRequest, sparqlPostRequest: themesSparqlPostRequest } = useSparqlRequest();
+const { loading: searchLoading, error: searchError, sparqlGetRequest: searchSparqlGetRequest, sparqlPostRequest: searchSparqlPostRequest } = useSparqlRequest();
 const { store, parseIntoStore, qnameToIri } = useRdfStore();
 
 const LIVE_SEARCH = true;
@@ -135,7 +135,7 @@ async function getCatalogs() {
  * Gets a list of themes from a SPARQL query from the API & creates the list of theme options
  */
 async function getThemes() {
-    const themesData = await themesSparqlGetRequest(`${apiBaseUrl}/sparql`, getThemesQuery(selectedCatalogs.value));
+    const themesData = await themesSparqlPostRequest(`${apiBaseUrl}/sparql`, getThemesQuery(selectedCatalogs.value));
     if (themesData && !themesError.value) {
         themes.value = (themesData.results.bindings as SparqlBinding[]).map(result => {
             return {
@@ -150,7 +150,7 @@ async function getThemes() {
  * Performs search via a SPARQL query
  */
 async function doSearch() {
-    const searchData = await searchSparqlGetRequest(`${apiBaseUrl}/sparql`, query.value);
+    const searchData = await searchSparqlPostRequest(`${apiBaseUrl}/sparql`, query.value);
     if (searchData && !searchError.value) {
         results.value = (searchData.results.bindings as SparqlBinding[]).map(result => {
             return {

--- a/src/components/search/SpacePrezSearchMap.vue
+++ b/src/components/search/SpacePrezSearchMap.vue
@@ -35,7 +35,7 @@ const mapConfig = inject(mapConfigKey) as MapConfig;
 
 const { loading: datasetLoading, error: datasetError, apiGetRequest: datasetApiGetRequest } = useApiRequest(); // list of datasets
 const { loading: fcLoading, hasError: fcError, concurrentApiRequests: fcConcurrentApiRequests } = useConcurrentApiRequests(); // concurrent lists of feature collections
-const { loading: searchLoading, error: searchError, sparqlGetRequest: searchSparqlGetRequest } = useSparqlRequest(); // spatial search SPARQL query
+const { loading: searchLoading, error: searchError, sparqlGetRequest: searchSparqlGetRequest, sparqlPostRequest: searchSparqlPostRequest } = useSparqlRequest(); // spatial search SPARQL query
 const { store, parseIntoStore, qnameToIri } = useRdfStore();
 
 const LIVE_SEARCH = true;
@@ -208,7 +208,7 @@ async function getDatasets() {
 
 async function doSearch() {
     if (shape.value.coords.length > 0) {
-        const searchData = await searchSparqlGetRequest(`${apiBaseUrl}/sparql`, query.value);
+        const searchData = await searchSparqlPostRequest(`${apiBaseUrl}/sparql`, query.value);
         if (searchData && !searchError.value) {
             results.value = (searchData.results.bindings as SparqlBinding[]).map(result => {
                 return {


### PR DESCRIPTION
Allows the use of the Prez /sparql passthrough endpoint using the POST method rather than GET.

This supports larger SPARQL queries on Prez APIs that do not support long query args in GET requests.

Fixes an issue on Azure APIM where it cannot accept an API route where the query param (/sparql?query=...) is longer than 2048 characters. It allows unlimited payload on POST.

I don't think this implementation is the cleanest way of doing it (all users of `useSparqlRequest()` get both a `sparqlGetRequest` fn and a `sparqlPostRequest` rn, and can use whichever they prefer). But it is the method I used to get around the issue.

This requires corresponding PR to be merged in backend Prez-api: https://github.com/RDFLib/prez/pull/239