### PR TITLE
Fix dom purify

### DIFF
--- a/packages/core/app/site/layouts/default.vue
+++ b/packages/core/app/site/layouts/default.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useGetPrezAPIAltEndpoints, useSetAPIEndpoint } from '../composables/useLib';
 
 const props = defineProps<{sidepanel?: boolean, contentonly?: boolean}>()
 const appConfig = useAppConfig();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@nuxtjs/tailwindcss": "^6.12.1",
     "@primevue/themes": "^4.0.4",
+    "dompurify": "^3.2.0",
     "dotenv-cli": "^7.4.2",
     "marked": "^15.0.0",
     "mermaid": "^10.9.1",
@@ -27,7 +28,6 @@
     "@rdfjs/types": "^1.1.0",
     "@triply/yasgui": "^4.2.28",
     "@types/n3": "^1.16.4",
-    "tailwindcss": "^3.4.9",
-    "vue-dompurify-html": "^5.1.0"
+    "tailwindcss": "^3.4.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@primevue/themes':
         specifier: ^4.0.4
         version: 4.0.5
+      dompurify:
+        specifier: ^3.2.0
+        version: 3.2.0
       dotenv-cli:
         specifier: ^7.4.2
         version: 7.4.2
@@ -102,9 +105,6 @@ importers:
       tailwindcss:
         specifier: ^3.4.9
         version: 3.4.10
-      vue-dompurify-html:
-        specifier: ^5.1.0
-        version: 5.1.0(vue@3.4.38)
 
   packages/lib:
     dependencies:
@@ -12577,8 +12577,8 @@ packages:
     resolution: {integrity: sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ==}
     dev: true
 
-  /dompurify@3.1.6:
-    resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
+  /dompurify@3.2.0:
+    resolution: {integrity: sha512-AMdOzK44oFWqHEi0wpOqix/fUNY707OmoeFDnbi3Q5I8uOpy21ufUA5cDJPr0bosxrflOVD/H2DMSvuGKJGfmQ==}
 
   /domutils@1.7.0:
     resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
@@ -17088,7 +17088,7 @@ packages:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.10
       dayjs: 1.11.13
-      dompurify: 3.1.6
+      dompurify: 3.2.0
       elkjs: 0.9.3
       katex: 0.16.11
       khroma: 2.1.0
@@ -24826,15 +24826,6 @@ packages:
       ts-map: 1.0.3
       vue: 3.4.38(typescript@5.6.2)
       vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.4.38)
-
-  /vue-dompurify-html@5.1.0(vue@3.4.38):
-    resolution: {integrity: sha512-616o2/PBdOLM2bwlRWLdzeEC9NerLkwiudqNgaIJ5vBQWXec+u7Kuzh+45DtQQrids67s4pHnTnJZLVfyPMxbA==}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      dompurify: 3.1.6
-      vue: 3.4.38(typescript@5.6.2)
-    dev: true
 
   /vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.4.38):
     resolution: {integrity: sha512-K3wt3iVmNGaFEOUR4JIThQRWfqokxLfnPslD41FDZB2ajXp789+wCqJyGYlIFsvEQ2P61PInw6/ph5iiqg51gg==}


### PR DESCRIPTION
Move to a simple sanitize function to keep dom purify integration simpler.

Note on loading the global config:
- If you have a custom layer project with a custom layout you will need to add a reference to the global config composable
- Currently, this is the only place where it is loaded, and we need to load it to build the dynamic SPARQL menu.

Required reference:
- const globalConfig = useGlobalConfig();
