### PR TITLE
Pagination fix

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -102,7 +102,7 @@ The most common case of theming Prez UI is adding a header, a footer, and modify
 Prez UI uses the [prez-components](https://github.com/rdflib/prez-ui/tree/main/packages/prez-components) component library, which is based on the [shadcn-vue](https://www.shadcn-vue.com) component library. Shad comes preinstalled in this starter template (`badge`, `button`, `input` & `pagination` are included as the base layer requires them), but if you need to add more shadcn components in your theme, run a command like the following to add the component:
 
 ```bash
-npx shadcn-vue@latest add button
+npx shadcn-vue@0 add button
 ```
 *(Note: for pnpm, run `pnpm dlx` instead of `npx`)*
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -128,3 +128,23 @@ export default defineNuxtConfig({
     ...
 });
 ```
+
+`app.config.ts` is where you can configure smaller content-related options such as the nav content, naming on certains items, and breadcrumbs. For overriding array variables such as `menu`, use the arrow function syntax instead of re-setting the variable:
+
+```typescript
+// app.config.ts example
+export default defineAppConfig({
+    ...
+    menu: () => [
+        { "label": "Home", "url": "/", "active": true },
+        { "label": "Catalogs", "url": "/catalogs", "active": true },
+        { "label": "Search", "url": "/search", "active": true },
+        { "label": "SPARQL", "url": "/sparql", "active": false },
+        { "label": "Profiles", "url": "/profiles", "active": true },
+        { "label": "About", "url": "/about", "active": true },
+        { "label": "API Documentation", "url": "/docs", "active": true },
+        { "label": "Custom link", "url": "/custom", "active": true },
+    ],
+    ...
+});
+```

--- a/packages/create-prez-app/template/components/ui/button/Button.vue
+++ b/packages/create-prez-app/template/components/ui/button/Button.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
   <Primitive
     :as="as"
     :as-child="asChild"
-    :class="cn(buttonVariants({ variant, size }), props.class)"
+    :class="cn('btn', buttonVariants({ variant, size }), props.class)"
   >
     <slot />
   </Primitive>

--- a/packages/prez-components/src/assets/index.css
+++ b/packages/prez-components/src/assets/index.css
@@ -77,7 +77,7 @@
     }
 }
 
-a:not(header a):not(nav.main-nav a):not(.btn) {
+a:not(header a):not(nav.main-nav a):not(footer a):not(.btn) {
     color: hsl(var(--link));
 }
 

--- a/packages/prez-components/src/components/ItemBreadcrumb.vue
+++ b/packages/prez-components/src/components/ItemBreadcrumb.vue
@@ -8,6 +8,7 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { ChevronRight } from 'lucide-vue-next';
 import { ItemBreadcrumbProps } from "@/types";
 import Literal from "./Literal.vue";
 import ItemLink from "./ItemLink.vue";
@@ -34,8 +35,8 @@ const lastUrl = links[links.length - 1]?.url;
 
 <template>
     <!-- ItemBreadcrumb -->
-    <Breadcrumb v-if="links">
-        <BreadcrumbList class="text-muted-foreground">
+    <Breadcrumb v-if="links" class="breadcrumbs">
+        <BreadcrumbList>
             <template v-for="item in links">
                 <BreadcrumbItem>
                     <component :is="item.url != lastUrl ? BreadcrumbLink : BreadcrumbPage" as-child>
@@ -49,7 +50,9 @@ const lastUrl = links[links.length - 1]?.url;
                         </component>
                     </component>
                 </BreadcrumbItem>
-                <BreadcrumbSeparator v-if="item.url != lastUrl" />
+                <BreadcrumbSeparator v-if="item.url != lastUrl" class="breadcrumb-separator">
+                    <ChevronRight class="size-4" />
+                </BreadcrumbSeparator>
             </template>
         </BreadcrumbList>
     </Breadcrumb>

--- a/packages/prez-components/src/components/ItemLink.vue
+++ b/packages/prez-components/src/components/ItemLink.vue
@@ -103,7 +103,7 @@ const linkClass = props.class ? defaultClasses + ' ' + props.class : defaultClas
                     <slot />
                 </RouterLink>
             </template>
-            <span v-else class="border-b-[2px] border-transparent">
+            <span v-else>
                 <slot />
             </span>
             <template v-if="secondaryUrl && !hideSecondaryLink">

--- a/packages/prez-components/src/components/Literal.vue
+++ b/packages/prez-components/src/components/Literal.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, nextTick } from "vue";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 import mermaid from "mermaid";
+import { Link } from "lucide-vue-next";
 import { type PrezLiteral, SYSTEM_PREDICATES } from "prez-lib";
 import { LiteralProps } from "@/types";
 import { isHtmlDetected, isMarkdownDetected } from "@/utils/helpers";
@@ -140,7 +141,10 @@ const htmlClass = 'no-tailwind' + (props.class ? ' ' + props.class : '');
                 <slot name="text" :term="term" :text="term.value">
                     <span v-if="isMarkdown" v-html="renderedMarkdownContent"></span>
                     <span v-else-if="isHtml" :class="htmlClass" v-html="sanitizedHtml"></span>
-                    <span v-else :class="class">{{ term.value }}</span>
+                    <span v-else :class="class">
+                        <a v-if="term.value.startsWith('http')" :href="term.value" target="_blank" rel="noopener noreferrer" class="inline-flex gap-1 items-center">{{ term.value }} <Link class="size-4" /></a>
+                        <template v-else>{{ term.value }}</template>
+                    </span>
                 </slot>
                 <slot v-if="!hideLanguage && term.language !== undefined" name="language" :term="term" :language="term.language">
                     <div class="pt-1">

--- a/packages/prez-components/src/components/Message.vue
+++ b/packages/prez-components/src/components/Message.vue
@@ -8,7 +8,7 @@ const props = defineProps<MessageProps>();
 
 <template>
     <!-- Message -->
-    <Alert :variant="props.severity === 'error' ? 'destructive' : 'default'">
+    <Alert :variant="props.severity === 'error' ? 'destructive' : 'default'" class="message">
         <CircleX v-if="props.severity === 'error'" class="w-4 h-4" />
         <Info v-else class="w-4 h-4" />
         <AlertTitle>{{ props.severity === "error" ? "Error" : "Message" }}</AlertTitle>

--- a/packages/prez-components/src/components/Objects.vue
+++ b/packages/prez-components/src/components/Objects.vue
@@ -15,7 +15,7 @@ const props = withDefaults(defineProps<ObjectsProps>(), {
 <template>
     <!-- Objects -->
     <slot>
-        <div v-for="(obj, index) of props.objects" :key="index" >
+        <div v-for="(obj, index) of props.objects" :key="index" class="objects">
             <component
                 :is="props._components.term"
                 :term="obj"

--- a/packages/prez-components/src/components/SearchResults.vue
+++ b/packages/prez-components/src/components/SearchResults.vue
@@ -23,9 +23,9 @@ const props = withDefaults(defineProps<SearchResultsProps>(), {
         <TableBody>
             <TableRow v-for="result in props.results.sort((a, b) => b.weight - a.weight)">
                 <TableCell>
-                    <span class="float-right">
-                        <Badge variant="outline" class="text-xs">
-                            <component :is="props._components.node" :term="result.predicate" variant="search-results" />
+                    <span class="float-right flex flex-row gap-1">
+                        <Badge v-for="type in result.resource.rdfTypes" variant="outline" class="text-xs">
+                            <component :is="props._components.node" :term="type" variant="search-results" />
                         </Badge>
                     </span>
                     <b><component :is="props._components.term" :term="result.resource" variant="search-results" /></b>

--- a/packages/prez-components/src/components/SearchResults.vue
+++ b/packages/prez-components/src/components/SearchResults.vue
@@ -1,10 +1,14 @@
 <script lang="ts" setup>
-import { Badge } from '@/components/ui/badge'
-import { Table, TableBody, TableRow, TableCell } from '@/components/ui/table';
+import { ChevronRight, Info } from "lucide-vue-next";
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Table, TableBody, TableRow, TableCell } from "@/components/ui/table";
 import { SearchResultsProps } from "@/types";
 import Node from "./Node.vue";
 import Term from "./Term.vue";
 import Literal from "./Literal.vue";
+import { PrezFocusNode, PrezLinkParent } from "prez-lib";
+import ItemLink from "./ItemLink.vue";
 
 const props = withDefaults(defineProps<SearchResultsProps>(), {
     _components: () => {
@@ -12,9 +16,15 @@ const props = withDefaults(defineProps<SearchResultsProps>(), {
             node: Node,
             term: Term,
             literal: Literal,
+            itemLink: ItemLink,
         }
     }
 });
+
+function getParent(resource: PrezFocusNode): PrezLinkParent | undefined {
+    // TODO: self should not be listed in parents
+    return resource.links?.map(l => l.parents?.filter(p => p.label && p.url !== l.value).slice(-1)[0])[0];
+}
 </script>
 
 <template>
@@ -22,16 +32,35 @@ const props = withDefaults(defineProps<SearchResultsProps>(), {
     <Table v-if="props.results.length" class="search-results">
         <TableBody>
             <TableRow v-for="result in props.results.sort((a, b) => b.weight - a.weight)">
-                <TableCell>
-                    <span class="float-right flex flex-row gap-1">
-                        <Badge v-for="type in result.resource.rdfTypes" variant="outline" class="text-xs">
-                            <component :is="props._components.node" :term="type" variant="search-results" />
-                        </Badge>
-                    </span>
-                    <b><component :is="props._components.term" :term="result.resource" variant="search-results" /></b>
+                <TableCell class="flex flex-col gap-1">
+                    <div class="flex flex-row items-center gap-2">
+                        <template v-for="parent in [getParent(result.resource)]">
+                            <span v-if="parent" class="inline-flex flex-row items-center gap-1">
+                                <component :is="props._components.itemLink" :to="parent.url" variant="search-results">{{ parent.label?.value }}</component>
+                                <ChevronRight class="size-4" />
+                            </span>
+                        </template>
+                        <span class="font-bold mr-auto">
+                            <component :is="props._components.term" :term="result.resource" variant="search-results" />
+                        </span>
+                        <span class="flex flex-row gap-1">
+                            <Badge v-for="type in result.resource.rdfTypes" variant="outline" class="text-xs">
+                                <component :is="props._components.node" :term="type" variant="search-results" />
+                            </Badge>
+                        </span>
+                        <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger class="cursor-default">
+                                    <span class="text-muted-foreground"><Info class="size-4" /></span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    Matched on <component :is="props._components.node" :term="result.predicate" variant="search-results" />
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+                    </div>
                     <div v-if="result.resource.description">
-                        <component :is="props._components.literal" class="overflow-hidden text-ellipsis line-clamp-3" hide-language
-                            :term="result.resource.description" />
+                        <component :is="props._components.literal" class="overflow-hidden text-ellipsis line-clamp-3 text-muted-foreground italic text-sm" hide-language :term="result.resource.description" />
                     </div>
                 </TableCell>
             </TableRow>

--- a/packages/prez-components/src/components/ui/tooltip/Tooltip.vue
+++ b/packages/prez-components/src/components/ui/tooltip/Tooltip.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { TooltipRootEmits, TooltipRootProps } from 'radix-vue'
+import { TooltipRoot, useForwardPropsEmits } from 'radix-vue'
+
+const props = defineProps<TooltipRootProps>()
+const emits = defineEmits<TooltipRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <TooltipRoot v-bind="forwarded">
+    <slot />
+  </TooltipRoot>
+</template>

--- a/packages/prez-components/src/components/ui/tooltip/TooltipContent.vue
+++ b/packages/prez-components/src/components/ui/tooltip/TooltipContent.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { TooltipContentEmits, TooltipContentProps } from 'radix-vue'
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+import { TooltipContent, TooltipPortal, useForwardPropsEmits } from 'radix-vue'
+import { computed } from 'vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(defineProps<TooltipContentProps & { class?: HTMLAttributes['class'] }>(), {
+  sideOffset: 4,
+})
+
+const emits = defineEmits<TooltipContentEmits>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <TooltipPortal>
+    <TooltipContent v-bind="{ ...forwarded, ...$attrs }" :class="cn('z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2', props.class)">
+      <slot />
+    </TooltipContent>
+  </TooltipPortal>
+</template>

--- a/packages/prez-components/src/components/ui/tooltip/TooltipProvider.vue
+++ b/packages/prez-components/src/components/ui/tooltip/TooltipProvider.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import type { TooltipProviderProps } from 'radix-vue'
+import { TooltipProvider } from 'radix-vue'
+
+const props = defineProps<TooltipProviderProps>()
+</script>
+
+<template>
+  <TooltipProvider v-bind="props">
+    <slot />
+  </TooltipProvider>
+</template>

--- a/packages/prez-components/src/components/ui/tooltip/TooltipTrigger.vue
+++ b/packages/prez-components/src/components/ui/tooltip/TooltipTrigger.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import type { TooltipTriggerProps } from 'radix-vue'
+import { TooltipTrigger } from 'radix-vue'
+
+const props = defineProps<TooltipTriggerProps>()
+</script>
+
+<template>
+  <TooltipTrigger v-bind="props">
+    <slot />
+  </TooltipTrigger>
+</template>

--- a/packages/prez-components/src/components/ui/tooltip/index.ts
+++ b/packages/prez-components/src/components/ui/tooltip/index.ts
@@ -1,0 +1,4 @@
+export { default as Tooltip } from './Tooltip.vue'
+export { default as TooltipContent } from './TooltipContent.vue'
+export { default as TooltipProvider } from './TooltipProvider.vue'
+export { default as TooltipTrigger } from './TooltipTrigger.vue'

--- a/packages/prez-components/src/types.ts
+++ b/packages/prez-components/src/types.ts
@@ -181,6 +181,7 @@ export interface SearchResultsProps {
         node: Component;
         term: Component;
         literal: Component;
+        itemLink: Component;
     };
 };
 

--- a/packages/prez-ui/components/ConceptHierarchy.vue
+++ b/packages/prez-ui/components/ConceptHierarchy.vue
@@ -51,7 +51,7 @@ function loadMore() {
 </script>
 
 <template>
-    <div v-if="data?.data">
+    <div v-if="data?.data" class="concept-hierarchy">
         <div v-if="data.data.length == 0" class="text-muted-foreground text-sm">No concepts found</div>
         <div v-else v-for="concept of concepts" :key="concept.value" class="pz-concept flex flex-col gap-1">
             <div class="pz-concept-node h-9">

--- a/packages/prez-ui/components/LayoutFooter.vue
+++ b/packages/prez-ui/components/LayoutFooter.vue
@@ -6,7 +6,7 @@ const altEndpoints = useGetPrezAPIAltEndpoints();
 </script>
 
 <template>
-    <footer class="bg-tertiary text-secondary-foreground pt-6 pb-10">
+    <footer class="bg-tertiary text-tertiary-foreground pt-6 pb-10">
         <div class="container mx-auto text-center">
             <div class="text-sm">
                 <div>

--- a/packages/prez-ui/components/LayoutHeader.vue
+++ b/packages/prez-ui/components/LayoutHeader.vue
@@ -1,5 +1,5 @@
 <template>
-    <header class="bg-tertiary text-secondary-foreground h-32">
+    <header class="bg-tertiary text-tertiary-foreground h-32">
         <div class="container mx-auto px-4 h-full flex justify-between items-center">
             <NuxtLink to="/" class="text-4xl hidden md:block">
                 <slot name="logo">

--- a/packages/prez-ui/components/ListPage.vue
+++ b/packages/prez-ui/components/ListPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { dumpNodeArray } from 'prez-lib';
+import { dumpNodeArray } from "prez-lib";
 
 const appConfig = useAppConfig();
 const route = useRoute();
@@ -11,13 +11,13 @@ const { status, error, data } = useGetList(apiEndpoint, urlPath);
 
 const { getPageUrl, pagination } = usePageInfo(data);
 
-const apiUrl = (apiEndpoint + urlPath.value).split('?')[0];
-const currentProfile = computed(()=>data.value ? data.value.profiles.find(p=>p.current) : undefined);
+const apiUrl = (apiEndpoint + urlPath.value).split("?")[0];
+const currentProfile = computed(() => data.value ? data.value.profiles.find(p => p.current) : undefined);
 
-const header = computed(()=>{
+const header = computed(() => {
     const lastParent = data.value && data.value.parents?.length > 0
         ? data.value.parents[data.value.parents.length - 1]!.segment : false;
-    return lastParent ? appConfig.nameSubstitutions?.[lastParent] || lastParent : '';
+    return lastParent ? appConfig.nameSubstitutions?.[lastParent] || lastParent : "";
 });
 
 // when a new page is navigated to
@@ -34,14 +34,14 @@ watch(() => route.fullPath, () => {
             </slot>
         </template>
         <template #debug>
-            <pre class="p-2"><b>{{currentProfile?.title}}</b><br>{{ dumpNodeArray(globalProfiles?.[currentProfile?.uri || '']) }}</pre>
+            <pre class="p-2"><b>{{ currentProfile?.title }}</b><br>{{ dumpNodeArray(globalProfiles?.[currentProfile?.uri || '']) }}</pre>
         </template>
         <template #breadcrumb>
             <slot name="breadcrumb" :data="data">
                 <div :key="data?.parents.join()">
                     <ItemBreadcrumb v-if="data" :prepend="appConfig.breadcrumbPrepend || []" :name-substitutions="appConfig.nameSubstitutions" :parents="data.parents" />
-                    <ItemBreadcrumb v-else-if="error" :custom-items="[{url: '/', label: 'Unable to load page'}]" />
-                    <ItemBreadcrumb v-else :prepend="appConfig.breadcrumbPrepend" :custom-items="[{url: '#', label: '...'}]" />
+                    <ItemBreadcrumb v-else-if="error" :custom-items="[{ url: '/', label: 'Unable to load page' }]" />
+                    <ItemBreadcrumb v-else :prepend="appConfig.breadcrumbPrepend" :custom-items="[{ url: '#', label: '...' }]" />
                 </div>
             </slot>
         </template>
@@ -56,16 +56,12 @@ watch(() => route.fullPath, () => {
                 </slot>
 
                 <slot v-else-if="status == 'pending'" name="loading" :status="status">
-                    <Loading  />
+                    <Loading />
                 </slot>
 
                 <div v-else-if="data?.data">
                     <slot name="list-top" :data="data"></slot>
-                    <ItemList 
-                        v-if="globalProfiles && currentProfile"
-                        :fields="globalProfiles?.[currentProfile?.uri || '']"
-                        :list="data.data" :key="urlPath" 
-                    />
+                    <ItemList v-if="globalProfiles && currentProfile" :fields="globalProfiles?.[currentProfile?.uri || '']" :list="data.data" :key="urlPath" />
 
                     <slot name="pagination" :data="data" :pagination="pagination">
                         <PrezPagination :totalItems="data.count" :pagination="pagination" :maxReached="data.maxReached" />
@@ -83,5 +79,5 @@ watch(() => route.fullPath, () => {
             <ItemProfiles :key="status" :apiUrl="apiUrl" :loading="status == 'pending'" :profiles="data?.profiles" />
         </template>
 
-</NuxtLayout>
+    </NuxtLayout>
 </template>

--- a/packages/prez-ui/components/PrezPagination.vue
+++ b/packages/prez-ui/components/PrezPagination.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
                 </PaginationFirst>
                 <PaginationPrev as-child>
                     <Button class="w-10 h-10 p-0" variant="outline" as-child>
-                        <NuxtLink :to="{...route, query: { ...route.query, page: (parseInt(route.query.page as string) - 1).toString() }}">
+                        <NuxtLink :to="{...route, query: { ...route.query, page: (props.pagination.page - 1).toString() }}">
                             <ChevronLeft class="size-4" />
                         </NuxtLink>
                     </Button>
@@ -50,14 +50,14 @@ const props = defineProps<{
 
                 <PaginationNext as-child>
                     <Button class="w-10 h-10 p-0" variant="outline" as-child>
-                        <NuxtLink :to="{...route, query: { ...route.query, page: (parseInt(route.query.page as string) + 1).toString() }}">
+                        <NuxtLink :to="{...route, query: { ...route.query, page: (props.pagination.page + 1).toString() }}">
                             <ChevronRight class="size-4" />
                         </NuxtLink>
                     </Button>
                 </PaginationNext>
                 <PaginationLast as-child>
                     <Button class="w-10 h-10 p-0" variant="outline" as-child>
-                        <NuxtLink :to="{...route, query: { ...route.query, page: items.length.toString() }}">
+                        <NuxtLink :to="{...route, query: { ...route.query, page: Math.ceil(props.totalItems / props.pagination.limit).toString() }}">
                             <ChevronsRight class="size-4" />
                         </NuxtLink>
                     </Button>

--- a/packages/prez-ui/components/PrezPagination.vue
+++ b/packages/prez-ui/components/PrezPagination.vue
@@ -21,8 +21,8 @@ const props = defineProps<{
 </script>
 
 <template>
-    <div class="flex flex-col gap-2 mt-4">
-        <Pagination v-if="props.totalItems > props.pagination.limit" v-slot="{ page }" :total="props.totalItems" :itemsPerPage="props.pagination.limit" :sibling-count="1" show-edges :page="props.pagination.page">
+    <div class="flex flex-col gap-2 mt-4 pagination">
+        <Pagination v-if="props.totalItems > props.pagination.limit" v-slot="{ page }" :total="props.totalItems" :itemsPerPage="props.pagination.limit" :sibling-count="1" show-edges :page="props.pagination.page" class="paginator">
             <PaginationList v-slot="{ items }" class="flex items-center gap-1 justify-center">
                 <PaginationFirst as-child>
                     <Button class="w-10 h-10 p-0" variant="outline" as-child>
@@ -64,7 +64,7 @@ const props = defineProps<{
                 </PaginationLast>
             </PaginationList>
         </Pagination>
-        <div v-if="props.totalItems > 0" class="text-sm text-muted-foreground text-center">
+        <div v-if="props.totalItems > 0" class="pagination-text text-sm text-muted-foreground text-center">
             Showing {{ props.pagination.first }} to 
                 {{ Math.min(props.pagination.first + props.pagination.limit - 1, props.totalItems) }} of 
                 {{ props.totalItems }}{{ props.maxReached ? '+' : '' }} items

--- a/packages/prez-ui/components/SearchResults.vue
+++ b/packages/prez-ui/components/SearchResults.vue
@@ -5,8 +5,9 @@ const props = defineProps<SearchResultsProps>();
 const node = resolveComponent("Node") as Component;
 const term = resolveComponent("Term") as Component;
 const literal = resolveComponent("Literal") as Component;
+const itemLink = resolveComponent("ItemLink") as Component;
 </script>
 
 <template>
-    <SearchResults v-bind="props" :_components="{node, term, literal}" />
+    <SearchResults v-bind="props" :_components="{node, term, literal, itemLink}" />
 </template>

--- a/packages/prez-ui/layouts/default.vue
+++ b/packages/prez-ui/layouts/default.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
     contentonly?: boolean;
 }>();
 const runtimeConfig = useRuntimeConfig();
+const globalConfig = useGlobalConfig(); // needed for checking if SPARQL is enabled
 const expandSidePanel = ref(false);
 const showDebugPanel = ref(false);
 


### PR DESCRIPTION
- Fixed issues with next & last page buttons in `PrezPagination.vue`
- Added more classes to components for selecting in CSS
- Badges in search results now display the resource types instead of the matched predicate
- Added some documentation on how to override array variables in app config
- Improved the default CSS to avoid unnecessarily specific CSS rules to style links
- Moved the call to `useGlobalConfig()` to the default layout
- Search results now display closest parent if exists
- Search results now have a tooltip for viewing matched predicate
- Literals now render as links if they start with `http`

![Screenshot 2025-03-13 at 2 38 24 pm](https://github.com/user-attachments/assets/57a4eb4a-590a-4b19-8374-fbe1896de403)
![Screenshot 2025-03-13 at 2 40 14 pm](https://github.com/user-attachments/assets/0ba569c4-5251-408f-b967-eacf5ff5e610)


Resolves #185 