### PR TITLE
fix: remove sourcemaps

### DIFF
--- a/packages/prez-lib/vite.config.ts
+++ b/packages/prez-lib/vite.config.ts
@@ -11,8 +11,7 @@ export default defineConfig({
             entry: resolve(__dirname, "src/index.ts"),
             name: "prez-lib",
             fileName: "prez-lib",
-        },
-        sourcemap: true
+        }
     },
     resolve: {
         alias: {


### PR DESCRIPTION
Remove sourcemaps from prez-lib build.

Potentially causing a mime-type issue when serving built assets on S3/CloudFront.

The inclusion of sourcemaps altered the build output (JS filenames, content, added .map files). This change appears to have interacted negatively with the deployment environment's configuration, resulting in JavaScript files being served with an incorrect `text/html` MIME type, not seen in local dev.
