### PR TITLE
PrezTerm parsing issue

### DIFF
--- a/packages/prez-lib/src/types.ts
+++ b/packages/prez-lib/src/types.ts
@@ -9,6 +9,7 @@ import type { RDFStore } from "./store";
  */
 export type PrezTerm = (PrezLiteral | PrezNode | PrezBlankNode | PrezFocusNode) & {
     /**
+     * Address infinite recursion during term processing
      * Internal property for cycle detection during term processing
      * Points to the parent term being processed in the call chain
      */


### PR DESCRIPTION
Address the issue described in #221. 

This change has inadvertently ended up on main under this commit - https://github.com/RDFLib/prez-ui/commit/61df5771a88fc860202c47fd16390e3b9e4ccc82. Won't impact existing release packages.  Any additions to that commit can be captured as part of this branch.

These changes implement cycle detection in the toPrezTerm method by adding a parent parameter that tracks the call chain, preventing infinite loops when RDF data contains circular references (like a literal pointing to its datatype which points back to the literal).

Introduces a new _cycleParent property to PrezTerm to track the parent on a term. This property is only intended for use when creating a PrezTerm via toPrezTerm.

Alternate solutions could be done using a Set, as per this branch - https://github.com/RDFLib/prez-ui/compare/main...david/parsing-issue.

Looking for feedback on the approaches of a separate Set vs adding the parent to PrezTerm, as added in the commit above.

Note: to test, you'll need to point your env to a new 4.15.x API endpoint. More complete testing is still required against additional new API test endpoints.