### PR TITLE
fix: address profiles link error where query param iri is used instea…

### DIFF
--- a/packages/prez-ui/app/components/ItemPage.vue
+++ b/packages/prez-ui/app/components/ItemPage.vue
@@ -136,7 +136,7 @@ watch([() => globalProfiles.value, () => currentProfile.value], ([newGlobalProfi
 
         <template #sidepanel>
             <slot name="profiles" :data="data" :apiUrl="apiUrl" :status="status">
-                <ItemProfiles :key="status" :objectUri="(route.query.uri as string)" :apiUrl="apiUrl" :loading="status == 'pending'" :profiles="data?.profiles" />
+                <ItemProfiles :key="status" :objectUri="data?.data.value" :apiUrl="apiUrl" :loading="status == 'pending'" :profiles="data?.profiles" />
             </slot>
         </template>
 


### PR DESCRIPTION
Simple link issue outlined in https://github.com/RDFLib/prez/issues/443.

Alternate profiles link on the first link is broken:
- https://data.idnau.org/object?iri=https://data.idnau.org/pid/vocab/cat-roles/original
- https://data.idnau.org/object?uri=https://data.idnau.org/pid/vocab/cat-roles/original

Both object link constructions should be supported. This update uses the IRI from the loaded data object, instead of referencing a query param directly.