### PR TITLE
feat(prez-lib): add Jena Lucene SHACL search parser mode

### DIFF
--- a/docs/2026-04-15-jena-lucene-shacl-search-design.md
+++ b/docs/2026-04-15-jena-lucene-shacl-search-design.md
@@ -1,0 +1,411 @@
+# Jena Lucene SHACL Search Support Design
+
+Date: 2026-04-15
+
+## Goal
+
+Add opt-in support in `prez-lib` for the Jena Lucene SHACL search result shape, without changing default behavior for existing Prez installations.
+
+Implementation scope for this change:
+
+- `prez-lib` only
+
+This repo also contains `prez-ui`, but that is not the delivery target for this change. The immediate consumer is an external Angular application that uses `prez-lib` directly.
+
+The support needs to handle two cases:
+
+1. `q` is supplied: search results include nested match nodes.
+2. `q` is not supplied: search results still include scored hits and IRIs, but no nested match nodes.
+
+## Current Behavior
+
+`prez-lib` currently assumes a flat search result model.
+
+Current parser entry points:
+
+- `packages/prez-lib/src/service.ts`
+- `packages/prez-lib/src/store.ts`
+- `packages/prez-lib/src/types.ts`
+
+Current assumptions in `RDFStore.search()`:
+
+- each `prez:SearchResult` has exactly one `prez:searchResultPredicate`
+- each `prez:SearchResult` has exactly one `prez:searchResultMatch`
+- each `prez:SearchResult` has exactly one `prez:searchResultURI`
+
+That maps to the current type:
+
+```ts
+type PrezSearchResult = {
+  hash: string;
+  weight: number;
+  predicate: PrezNode;
+  match: PrezLiteral;
+  resource: PrezFocusNode;
+};
+```
+
+This does not fit the Jena Lucene SHACL shape where a result node contains zero or more nested match nodes via `prez:hasSearchMatch`.
+
+## Observed Jena Lucene SHACL Shape
+
+At the result level:
+
+- `a prez:SearchResult`
+- `prez:searchResultWeight`
+- `prez:searchResultURI`
+- optional `prez:hasSearchMatch`
+
+At the nested match level:
+
+- `a prez:SearchResultMatch`
+- `prez:searchResultPredicate`
+- `prez:searchResultMatch`
+
+From the sample:
+
+```turtle
+<urn:hash:...> a prez:SearchResult ;
+    prez:searchResultWeight "8.222368"^^xsd:float ;
+    prez:searchResultURI gswa_site:mineral-drill-hole_M0003251 ;
+    prez:hasSearchMatch <urn:match:1>, <urn:match:2> .
+
+<urn:match:1> a prez:SearchResultMatch ;
+    prez:searchResultPredicate <urn:jena:lucene:field#comment> ;
+    prez:searchResultMatch "Drillcore donated by Gold Road Resources.\n" .
+```
+
+## Required Design Constraints
+
+This must be opt-in.
+
+This must also be a permanent dual-mode design.
+
+Default Prez behavior should continue to parse the current flat shape with no changes required by existing users.
+
+When the feature flag is enabled, the Jena Lucene SHACL parser and UI behavior should be used. When the flag is disabled, the existing flat parser and existing UI behavior should be used.
+
+## Proposed Design
+
+### 1. Use explicit mode-specific search models rather than heuristic compatibility fields
+
+Add a dedicated match type:
+
+```ts
+type PrezSearchMatch = {
+  predicate: PrezNode;
+  match: PrezLiteral;
+};
+```
+
+Keep the existing flat result type for default mode:
+
+```ts
+type PrezFlatSearchResult = {
+  hash: string;
+  weight: number;
+  predicate: PrezNode;
+  match: PrezLiteral;
+  resource: PrezFocusNode;
+};
+```
+
+Define a separate result type for Jena Lucene SHACL mode:
+
+```ts
+type PrezLuceneShaclSearchResult = {
+  hash: string;
+  weight: number;
+  resource: PrezFocusNode;
+  matches: PrezSearchMatch[];
+};
+```
+
+Rationale:
+
+- supports zero matches when `q` is absent
+- supports multiple matches when `q` is supplied
+- avoids duplicating the same resource into multiple rows
+- keeps the contract explicit: consumers know which model they asked for
+
+Do not synthesize `predicate` and `match` in Jena Lucene SHACL mode based on match count. Consumers of `prez-lib` should know which parser mode they configured and should receive the corresponding result shape directly.
+
+### 2. Introduce an explicit feature flag and parser mode
+
+Add an explicit parser mode in `prez-lib`.
+
+Consumer-facing feature flag example:
+
+```ts
+const useJenaLuceneShaclSearch = true;
+```
+
+Library-facing parser mode example:
+
+```ts
+type PrezSearchParserMode = "default" | "jena-lucene-shacl";
+```
+
+Thread that through the public API:
+
+```ts
+search(baseUrl, path, options?)
+```
+
+Possible option:
+
+```ts
+type PrezSearchOptions = {
+  parserMode?: PrezSearchParserMode;
+};
+```
+
+And reflect that in the returned search data type. Conceptually:
+
+```ts
+type PrezDataSearch =
+  | { type: "search"; parserMode: "default"; data: PrezFlatSearchResult[]; ... }
+  | { type: "search"; parserMode: "jena-lucene-shacl"; data: PrezLuceneShaclSearchResult[]; ... };
+```
+
+Behavior:
+
+- `default`: existing flat parser only
+- `jena-lucene-shacl`: parse result-level hits plus nested matches
+
+Mapping rule:
+
+- if the consumer feature flag is `false`, call `prez-lib.search(..., { parserMode: "default" })`
+- if the consumer feature flag is `true`, call `prez-lib.search(..., { parserMode: "jena-lucene-shacl" })`
+
+I do not recommend implicit auto-detection as the primary API. Permanent support for both modes is easier to reason about when the behavior is controlled explicitly by a feature flag.
+
+### 3. Add a dedicated predicate constant
+
+Add:
+
+```ts
+PREZ_PREDICATES.hasSearchMatch = "https://prez.dev/hasSearchMatch"
+```
+
+### 4. Split search parsing into helpers
+
+In `RDFStore.search()` replace the single flat mapping with mode-specific helpers:
+
+- `parseDefaultSearchResult(...)`
+- `parseJenaLuceneShaclSearchResult(...)`
+
+For the Jena Lucene SHACL mode:
+
+1. find all `rdf:type prez:SearchResult` subjects
+2. read `prez:searchResultWeight`
+3. read `prez:searchResultURI`
+4. read zero or more `prez:hasSearchMatch` objects
+5. for each match node, read `prez:searchResultPredicate` and `prez:searchResultMatch`
+6. build `matches[]`
+7. return the Jena Lucene SHACL result shape directly, without synthesizing flat fields
+
+### 5. UI impacts are downstream only for this change
+
+This repository contains `prez-ui`, so there are clear UI touch points if this search mode is ever wired into the bundled Nuxt application. Those are noted here for completeness only.
+
+They are not part of the implementation scope for this change.
+
+Current `prez-ui` `useSearch()` in `packages/prez-ui/app/composables/useLib.ts` exits early when `q` is absent:
+
+```ts
+const query = new URL(baseUrl + urlPath.value).searchParams.get("q");
+if (!query) {
+  return emptySearchResult;
+}
+```
+
+That means the UI will never request the backend shape you described for empty `q`.
+
+If `prez-ui` later needs to support that backend behavior, this guard must become configurable.
+
+Possible future UI runtime config:
+
+```ts
+public: {
+  prezJenaLuceneShaclSearch: boolean,
+  prezSearchAllowEmptyQuery: boolean
+}
+```
+
+Recommended behavior:
+
+- feature flag off: preserve current early-return behavior and current flat parsing
+- feature flag on: use Jena Lucene SHACL parsing and optionally allow requests without `q`
+
+## Touch Points
+
+### `packages/prez-lib`
+
+`src/types.ts`
+
+- add `PrezSearchMatch`
+- keep flat search result type for default mode
+- add dedicated Jena Lucene SHACL search result type
+- add `PrezSearchOptions` and parser mode type
+
+`src/consts.ts`
+
+- add `PREZ_PREDICATES.hasSearchMatch`
+
+`src/store.ts`
+
+- update `RDFStore.search()` to accept parser mode or options
+- add nested match parsing helper
+- preserve old flat parser behavior
+
+`src/service.ts`
+
+- extend exported `search()` signature to accept options
+- pass parser mode to the store
+
+`src/index.ts`
+
+- export new types if needed
+
+### `packages/prez-components` and `packages/prez-ui`
+
+These are downstream UI touch points only. They are not in scope for the current change, but they are the places that would need updates if the bundled UI were later taught to consume the new parser mode.
+
+`src/types.ts`
+
+- `SearchResultsProps` can likely stay the same if it already uses `PrezSearchResult[]`
+- type updates will flow from `prez-lib`
+
+`src/components/SearchResults.vue`
+
+- render zero, one, or many matches per result
+- handle results with no match snippets
+- decide how to show predicate information when there are multiple matches
+
+### `packages/prez-ui`
+
+`app/composables/useLib.ts`
+
+- map feature flag to `prez-lib.search()` parser mode
+- make the empty-`q` short-circuit depend on the feature flag and config
+
+`app/components/SearchResults.vue`
+
+- wrapper likely unchanged unless prop shape changes beyond `prez-components`
+
+`nuxt.config.ts` and/or runtime config
+
+- expose opt-in config so current users stay unchanged
+
+## Rendering Recommendation
+
+For the component layer, render per resource, not per match.
+
+Suggested row behavior:
+
+- title: result resource label
+- badges: resource RDF types
+- metadata: score if useful
+- match section:
+  - no matches: show nothing, or a muted "No match snippets returned"
+  - one match: current behavior
+  - many matches: render a short list of matched predicates and snippets
+
+This aligns with the backend semantics better than flattening each nested match into a separate top-level result row.
+
+## Potential Issues
+
+### Empty `q` is currently blocked in the UI, not in `prez-lib`
+
+`prez-lib` already fetches whatever search path it is given, including paths without `q`.
+
+The current blocker is `prez-ui`, where `useSearch()` returns an empty client-side result if `q` is absent and does not call `prez-lib.search()`.
+
+There is a separate parser issue in `prez-lib`: the current `RDFStore.search()` implementation assumes every `prez:SearchResult` has direct `prez:searchResultPredicate` and `prez:searchResultMatch` values. That means a no-`q` Jena Lucene SHACL response containing only score and hit IRI still requires parser changes, even though the fetch path already works in `prez-lib`.
+
+For this piece of work, the relevant action is the parser change in `prez-lib`. The `prez-ui` behavior is noted here only so future integrators are not surprised.
+
+### Search result typing should be explicit
+
+Existing code expects `predicate` and `match` to exist in the default mode. That should remain true.
+
+For Jena Lucene SHACL mode, consumers should not receive partially-compatible objects that sometimes expose flat fields and sometimes do not.
+
+The cleaner options are:
+
+1. separate result types per parser mode
+2. a discriminated `PrezDataSearch` union keyed by `parserMode`
+
+My recommendation is to make the mode explicit in the returned type contract and avoid compatibility synthesis inside the parser.
+
+### Multi-match UI behavior is a product decision
+
+If one resource matches multiple fields, the UI needs a rule for display:
+
+- first match only
+- all matches
+- first N matches with truncation
+
+I recommend rendering the first 2 to 3 matches and collapsing the rest.
+
+### Result ordering must stay result-level
+
+The backend score belongs to the resource hit, not to individual nested matches. That is another reason not to flatten nested matches into top-level rows.
+
+### Predicate labels may be weak
+
+The sample predicates use IRIs like `urn:jena:lucene:field#comment` and may not have `prez:label`.
+
+Possible result:
+
+- tooltip or inline text may show raw IRI or CURIE-like values
+
+This may be acceptable, but it should be expected in the UI.
+
+### Missing labels or descriptions on result resources
+
+If the backend only returns the hit IRI and limited annotations, search rows may become sparse. The parser can still work, but UX quality depends on how much of the focus node is materialized in the response.
+
+### Parser modes should be strict
+
+This implementation should assume the backend is configured for exactly one search result model at a time.
+
+That means:
+
+- `default` mode parses only the flat shape
+- `jena-lucene-shacl` mode parses only the nested match shape
+- if the backend returns the wrong shape for the configured parser mode, parsing should fail rather than trying to recover
+
+I do not want compatibility fallback logic here. Supporting mixed shapes in a single parser path creates unnecessary branching and makes the contract harder to reason about.
+
+## Recommended Implementation Order
+
+1. Add the design-compatible types in `prez-lib`.
+2. Add parser mode and nested match support in `RDFStore.search()`.
+3. Extend `service.ts` to expose the mode cleanly.
+4. Update `prez-components` search rendering for zero or many matches.
+5. Add `prez-ui` runtime config and relax the empty-`q` guard only when explicitly enabled.
+6. Add fixture-based tests for:
+   - current flat shape
+   - nested shape with one match
+   - nested shape with many matches
+   - nested shape with zero matches
+   - flat payload rejected in `jena-lucene-shacl` mode
+   - nested payload rejected in `default` mode
+
+## Recommendation
+
+Implement this as a permanent two-path design:
+
+- flat search behavior remains the default path
+- Jena Lucene SHACL behavior is activated by feature flag
+
+`prez-lib` should support both parser modes indefinitely.
+
+For this change, that is sufficient. External consumers, including the Angular client, can select the parser mode explicitly via their own feature flagging/configuration.
+
+The critical design choices are:
+
+- preserve one result row per resource and model nested snippets as `matches[]`, rather than flattening them into multiple top-level results
+- make the parser mode explicit in both configuration and returned data shape, rather than inferring behavior from how many matches happen to be present

--- a/packages/prez-lib/README.md
+++ b/packages/prez-lib/README.md
@@ -32,3 +32,19 @@ const store = new RDFStore();
 store.load(data);
 const data = store.getItem();
 ```
+
+## Search parser modes
+
+`search()` defaults to the existing flat Prez search result shape.
+
+The parser mode is strict: the mode you configure must match the backend search model. `prez-lib` does not do compatibility fallbacks between the flat and Jena Lucene SHACL shapes.
+
+To opt into Jena Lucene SHACL nested matches, pass the parser mode explicitly:
+
+```typescript
+import { search } from "prez-lib";
+
+const results = await search("https://example.com", "/search?q=rock", {
+    parserMode: "jena-lucene-shacl",
+});
+```

--- a/packages/prez-lib/package.json
+++ b/packages/prez-lib/package.json
@@ -29,6 +29,7 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
+        "test": "node --test tests/**/*.test.mjs",
         "types": "tsc",
         "preview": "vite preview",
         "preinstall": "npx only-allow pnpm"

--- a/packages/prez-lib/src/consts.ts
+++ b/packages/prez-lib/src/consts.ts
@@ -38,6 +38,7 @@ export const PREZ_PREDICATES = {
     searchResultPredicate: "https://prez.dev/searchResultPredicate",
     searchResultURI: "https://prez.dev/searchResultURI",
     searchResultMatch: "https://prez.dev/searchResultMatch",
+    hasSearchMatch: "https://prez.dev/hasSearchMatch",
     hasChildren: "https://prez.dev/hasChildren",
     facetCount: "https://prez.dev/facetCount",
     facetName: "https://prez.dev/facetName",

--- a/packages/prez-lib/src/service.ts
+++ b/packages/prez-lib/src/service.ts
@@ -1,4 +1,19 @@
-import type { PrezBlankNode, PrezDataItem, PrezDataList, PrezDataSearch, PrezNodeList, PrezProfileHeader, PrezProfiles, PrezProperties, PrezProperty } from "./types";
+import type {
+    PrezBlankNode,
+    PrezDataItem,
+    PrezDataList,
+    PrezDataSearch,
+    PrezDataSearchDefault,
+    PrezDataSearchLuceneShacl,
+    PrezNodeList,
+    PrezProfileHeader,
+    PrezProfiles,
+    PrezProperties,
+    PrezProperty,
+    PrezSearchOptions,
+    PrezSearchOptionsDefault,
+    PrezSearchOptionsLuceneShacl
+} from "./types";
 import { RDFStore } from "./store";
 import { SYSTEM_PREDICATES } from "./consts";
 
@@ -150,19 +165,37 @@ export async function getItem(baseUrl: string, path: string): Promise<PrezDataIt
  * @param path Search path along with any query parameters
  * @returns 
  */
-export async function search(baseUrl: string, path: string): Promise<PrezDataSearch> {
+export async function search(baseUrl: string, path: string, options?: PrezSearchOptionsDefault): Promise<PrezDataSearchDefault>;
+export async function search(baseUrl: string, path: string, options: PrezSearchOptionsLuceneShacl): Promise<PrezDataSearchLuceneShacl>;
+export async function search(baseUrl: string, path: string, options: PrezSearchOptions = {}): Promise<PrezDataSearch> {
     const url = baseUrl + path;
-    const pathOnly = new URL(url).pathname
+    const pathOnly = new URL(url).pathname;
     const { data, profiles } = await apiGet(url);
     const store = new RDFStore();
     store.setBaseUrl(baseUrl);
     store.load(data);
+    const parserMode = options.parserMode ?? "default";
+
+    if (parserMode === "jena-lucene-shacl") {
+        return {
+            type: 'search',
+            parserMode,
+            data: store.search({ parserMode }),
+            profiles,
+            maxReached: store.getMaxReached(),
+            count: store.getCount(),
+            parents: store.getParents(pathOnly),
+            facets: store.getFacets()
+        };
+    }
+
     return {
-        type: 'search', 
-        data: store.search(), 
-        profiles, 
-        maxReached: store.getMaxReached(), 
-        count: store.getCount(), 
+        type: 'search',
+        parserMode: "default",
+        data: store.search(),
+        profiles,
+        maxReached: store.getMaxReached(),
+        count: store.getCount(),
         parents: store.getParents(pathOnly),
         facets: store.getFacets()
     };

--- a/packages/prez-lib/src/store.ts
+++ b/packages/prez-lib/src/store.ts
@@ -1,5 +1,27 @@
 import { Store, Parser, DataFactory, type Quad_Object, type Quad_Subject, type Term, type Quad } from "n3";
-import type { PrezLiteral, PrezNode, PrezTerm, PrezProperties, PrezSearchResult, PrezFocusNode, PrezLink, PrezConceptSchemeNode, PrezConceptNode, PrezOntologyNode, PrezConceptSchemeOntologyNode, PrezBBlockNode, PrezLinkParent, PrezNodeList, PrezFacet } from "./types";
+import type {
+    PrezAnySearchResult,
+    PrezBBlockNode,
+    PrezConceptNode,
+    PrezConceptSchemeNode,
+    PrezConceptSchemeOntologyNode,
+    PrezFacet,
+    PrezFlatSearchResult,
+    PrezFocusNode,
+    PrezLink,
+    PrezLinkParent,
+    PrezLiteral,
+    PrezLuceneShaclSearchResult,
+    PrezNode,
+    PrezNodeList,
+    PrezOntologyNode,
+    PrezProperties,
+    PrezSearchMatch,
+    PrezSearchOptions,
+    PrezSearchOptionsDefault,
+    PrezSearchOptionsLuceneShacl,
+    PrezTerm
+} from "./types";
 import { DEFAULT_PREFIXES, PREZ_PREDICATES, SYSTEM_PREDICATES, BBLOCK_TYPES } from "./consts";
 import { defaultToIri, defaultFromIri } from "./helpers";
 import { node, literal, bnode } from "./factory";
@@ -161,6 +183,29 @@ export class RDFStore {
 
     private getObjectLiteral(iri: string, predicate: string): PrezLiteral | undefined {
         return this.getObjects(iri, predicate).map(o => this.toPrezTerm(o) as PrezLiteral)[0] || undefined;
+    }
+
+    private toSubjectTerm(subject: string | Quad_Subject | Quad_Object): Quad_Subject {
+        if (typeof subject === "string") {
+            return namedNode(subject);
+        }
+
+        if (subject.termType === "Literal") {
+            throw new Error(`Cannot use literal ${subject.value} as a subject.`);
+        }
+
+        return subject;
+    }
+
+    private getRequiredObject(subject: string | Quad_Subject | Quad_Object, predicate: string, description: string): Quad_Object {
+        const object = this.getObjects(subject, predicate)[0];
+
+        if (!object) {
+            const subjectValue = typeof subject === "string" ? subject : subject.value;
+            throw new Error(`Missing ${description} for ${subjectValue}.`);
+        }
+
+        return object;
     }
 
     public getProperties(term: Term, options?: {excludePrefix?: string, includePrefix?: string}): PrezProperties {
@@ -326,13 +371,14 @@ export class RDFStore {
      * @param predicate a string or string array of predicate IRIs
      * @returns the array of objects
      */
-    public getObjects(subject: string, predicate: string | string[]): Quad_Object[] {
+    public getObjects(subject: string | Quad_Subject | Quad_Object, predicate: string | string[]): Quad_Object[] {
+        const subjectTerm = this.toSubjectTerm(subject);
         if (typeof predicate === "string") {
-            return this.store.getObjects(namedNode(subject), namedNode(predicate), null);
+            return this.store.getObjects(subjectTerm, namedNode(predicate), null);
         } else {
             const objs: Quad_Object[] = [];
             predicate.forEach(p => {
-                objs.push(...this.store.getObjects(namedNode(subject), namedNode(p), null));
+                objs.push(...this.store.getObjects(subjectTerm, namedNode(p), null));
             });
             return objs;
         }
@@ -628,19 +674,89 @@ export class RDFStore {
     /**
      * Returns search results
      */
-    public search(): PrezSearchResult[] {
+    private extractSearchResultHash(subject: Quad_Subject): string {
+        return subject.value.startsWith("urn:hash:") ? subject.value.slice("urn:hash:".length) : subject.value;
+    }
+
+    private getSearchResultBase(subject: Quad_Subject) {
+        const weightObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultWeight, "search result weight");
+        const resourceObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultURI, "search result URI");
+
+        return {
+            hash: this.extractSearchResultHash(subject),
+            weight: Number(weightObject.value),
+            resource: this.toPrezFocusNode(resourceObject)
+        };
+    }
+
+    private getOptionalFlatSearchMatch(subject: Quad_Subject): PrezSearchMatch | undefined {
+        const predicateObject = this.getObjects(subject, PREZ_PREDICATES.searchResultPredicate)[0];
+        const matchObject = this.getObjects(subject, PREZ_PREDICATES.searchResultMatch)[0];
+
+        if (!predicateObject && !matchObject) {
+            return undefined;
+        }
+
+        if (!predicateObject || !matchObject) {
+            throw new Error(`Incomplete flat search match for ${subject.value}.`);
+        }
+
+        return {
+            predicate: this.toPrezTerm(predicateObject) as PrezNode,
+            match: this.toPrezTerm(matchObject) as PrezLiteral
+        };
+    }
+
+    private parseSearchMatch(subject: Quad_Object): PrezSearchMatch {
+        const predicateObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultPredicate, "search match predicate");
+        const matchObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultMatch, "search match literal");
+
+        return {
+            predicate: this.toPrezTerm(predicateObject) as PrezNode,
+            match: this.toPrezTerm(matchObject) as PrezLiteral
+        };
+    }
+
+    private parseDefaultSearchResult(subject: Quad_Subject): PrezFlatSearchResult {
+        if (this.getObjects(subject, PREZ_PREDICATES.hasSearchMatch).length > 0) {
+            throw new Error(`Received Lucene SHACL search matches for ${subject.value} while parserMode is default.`);
+        }
+
+        const flatMatch = this.getOptionalFlatSearchMatch(subject);
+
+        if (!flatMatch) {
+            throw new Error(`Missing flat search match data for ${subject.value}.`);
+        }
+
+        return {
+            ...this.getSearchResultBase(subject),
+            ...flatMatch
+        };
+    }
+
+    private parseJenaLuceneShaclSearchResult(subject: Quad_Subject): PrezLuceneShaclSearchResult {
+        const nestedMatchNodes = this.getObjects(subject, PREZ_PREDICATES.hasSearchMatch);
+        if (this.getOptionalFlatSearchMatch(subject)) {
+            throw new Error(`Received flat search match fields for ${subject.value} while parserMode is jena-lucene-shacl.`);
+        }
+
+        return {
+            ...this.getSearchResultBase(subject),
+            matches: nestedMatchNodes.map(matchNode => this.parseSearchMatch(matchNode))
+        };
+    }
+
+    public search(options?: PrezSearchOptionsDefault): PrezFlatSearchResult[];
+    public search(options: PrezSearchOptionsLuceneShacl): PrezLuceneShaclSearchResult[];
+    public search(options: PrezSearchOptions = {}): PrezAnySearchResult[] {
+        const parserMode = options.parserMode ?? "default";
         const resultSubjects = this.getSubjects(SYSTEM_PREDICATES.a, PREZ_PREDICATES.searchResult);
-        const results: PrezSearchResult[] = resultSubjects.map(s => {
-            const result: PrezSearchResult = {
-                hash: s.value.split("urn:hash:").slice(-1)[0]!,
-                weight: Number(this.getObjects(s.value, PREZ_PREDICATES.searchResultWeight)[0]!.value),
-                predicate: this.toPrezTerm(this.getObjects(s.value, PREZ_PREDICATES.searchResultPredicate)[0]!) as PrezNode,
-                match: this.toPrezTerm(this.getObjects(s.value, PREZ_PREDICATES.searchResultMatch)[0]!) as PrezLiteral,
-                resource: this.toPrezFocusNode(this.getObjects(s.value, PREZ_PREDICATES.searchResultURI)[0]!)
-            };
-            return result;
-        });
-        return results;
+
+        if (parserMode === "jena-lucene-shacl") {
+            return resultSubjects.map(subject => this.parseJenaLuceneShaclSearchResult(subject));
+        }
+
+        return resultSubjects.map(subject => this.parseDefaultSearchResult(subject));
     }
 
 

--- a/packages/prez-lib/src/types.ts
+++ b/packages/prez-lib/src/types.ts
@@ -211,16 +211,56 @@ export interface PrezProperties {
     [predicateIri: string]: PrezProperty;
 };
 
+export type PrezSearchParserMode = "default" | "jena-lucene-shacl";
+
+export type PrezSearchOptionsDefault = {
+    parserMode?: "default";
+};
+
+export type PrezSearchOptionsLuceneShacl = {
+    parserMode: "jena-lucene-shacl";
+};
+
+export type PrezSearchOptions = PrezSearchOptionsDefault | PrezSearchOptionsLuceneShacl;
+
 /**
- * Represents a search result
+ * Represents a single predicate/snippet pair inside a Lucene SHACL search result.
  */
-export type PrezSearchResult = {
+export type PrezSearchMatch = {
+    predicate: PrezNode;
+    match: PrezLiteral;
+};
+
+/**
+ * Represents the default flat Prez search result shape.
+ */
+export type PrezFlatSearchResult = {
     hash: string;
     weight: number;
     predicate: PrezNode;
     match: PrezLiteral;
     resource: PrezFocusNode;
 };
+
+/**
+ * Backwards-compatible alias for the default flat search result shape.
+ */
+export type PrezSearchResult = PrezFlatSearchResult;
+
+/**
+ * Represents the Jena Lucene SHACL search result shape.
+ */
+export type PrezLuceneShaclSearchResult = {
+    hash: string;
+    weight: number;
+    resource: PrezFocusNode;
+    matches: PrezSearchMatch[];
+};
+
+/**
+ * Represents any supported Prez search result shape.
+ */
+export type PrezAnySearchResult = PrezFlatSearchResult | PrezLuceneShaclSearchResult;
 
 /**
  * Represents an item in Prez that contains node info and its related properties
@@ -270,7 +310,7 @@ export type PrezDataTypes = 'item' | 'list' | 'search';
 
 export interface PrezData {
     type: PrezDataTypes;
-    data: PrezFocusNode | PrezFocusNode[] | PrezSearchResult[];
+    data: PrezFocusNode | PrezFocusNode[] | PrezAnySearchResult[];
     profiles: PrezProfileHeader[];
     parents: PrezLinkParent[];
     facets: PrezFacet[];
@@ -289,12 +329,24 @@ export interface PrezDataItem extends PrezData {
     store: RDFStore;
 }
 
-export interface PrezDataSearch extends PrezData {
+export interface PrezDataSearchBase extends Omit<PrezData, "type" | "data"> {
     type: 'search';
+    parserMode: PrezSearchParserMode;
     count: number;
-    data: PrezSearchResult[];
     maxReached: boolean;
 }
+
+export interface PrezDataSearchDefault extends PrezDataSearchBase {
+    parserMode: "default";
+    data: PrezFlatSearchResult[];
+}
+
+export interface PrezDataSearchLuceneShacl extends PrezDataSearchBase {
+    parserMode: "jena-lucene-shacl";
+    data: PrezLuceneShaclSearchResult[];
+}
+
+export type PrezDataSearch = PrezDataSearchDefault | PrezDataSearchLuceneShacl;
 
 export type PrezFacetValue = {
     term: (PrezLiteral | PrezNode);

--- a/packages/prez-lib/tests/fixtures/flat-search.ttl
+++ b/packages/prez-lib/tests/fixtures/flat-search.ttl
@@ -1,0 +1,16 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:hash:flat-1> a prez:SearchResult ;
+    prez:searchResultWeight "2.5"^^xsd:float ;
+    prez:searchResultPredicate ex:title ;
+    prez:searchResultMatch "Flat result match" ;
+    prez:searchResultURI ex:item-1 .
+
+ex:item-1 a ex:Thing ;
+    prez:label "Flat Item" ;
+    prez:description "Flat item description" .
+
+ex:title prez:label "Title" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/fixtures/lucene-mixed-shape.ttl
+++ b/packages/prez-lib/tests/fixtures/lucene-mixed-shape.ttl
@@ -1,0 +1,21 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:hash:mixed-1> a prez:SearchResult ;
+    prez:searchResultWeight "3.14"^^xsd:float ;
+    prez:searchResultPredicate ex:legacy ;
+    prez:searchResultMatch "Legacy flat snippet" ;
+    prez:searchResultURI ex:item-5 ;
+    prez:hasSearchMatch <urn:match:5> .
+
+<urn:match:5> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:nested ;
+    prez:searchResultMatch "Nested snippet wins" .
+
+ex:item-5 a ex:Thing ;
+    prez:label "Mixed Shape Item" .
+
+ex:legacy prez:label "Legacy" .
+ex:nested prez:label "Nested" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/fixtures/lucene-multi-match.ttl
+++ b/packages/prez-lib/tests/fixtures/lucene-multi-match.ttl
@@ -1,0 +1,28 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:hash:lucene-2> a prez:SearchResult ;
+    prez:searchResultWeight "5.5"^^xsd:float ;
+    prez:searchResultURI ex:item-3 ;
+    prez:hasSearchMatch <urn:match:2>, <urn:match:3>, <urn:match:4> .
+
+<urn:match:2> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:title ;
+    prez:searchResultMatch "First nested snippet" .
+
+<urn:match:3> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:comment ;
+    prez:searchResultMatch "Second nested snippet" .
+
+<urn:match:4> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:summary ;
+    prez:searchResultMatch "Third nested snippet" .
+
+ex:item-3 a ex:Thing ;
+    prez:label "Multi Match Item" .
+
+ex:title prez:label "Title" .
+ex:comment prez:label "Comment" .
+ex:summary prez:label "Summary" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/fixtures/lucene-single-match.ttl
+++ b/packages/prez-lib/tests/fixtures/lucene-single-match.ttl
@@ -1,0 +1,18 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:hash:lucene-1> a prez:SearchResult ;
+    prez:searchResultWeight "8.222368"^^xsd:float ;
+    prez:searchResultURI ex:item-2 ;
+    prez:hasSearchMatch <urn:match:1> .
+
+<urn:match:1> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:comment ;
+    prez:searchResultMatch "Single nested snippet" .
+
+ex:item-2 a ex:Thing ;
+    prez:label "Nested Item" .
+
+ex:comment prez:label "Comment" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/fixtures/lucene-zero-match.ttl
+++ b/packages/prez-lib/tests/fixtures/lucene-zero-match.ttl
@@ -1,0 +1,12 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<urn:hash:lucene-3> a prez:SearchResult ;
+    prez:searchResultWeight "1.75"^^xsd:float ;
+    prez:searchResultURI ex:item-4 .
+
+ex:item-4 a ex:Thing ;
+    prez:label "Zero Match Item" .
+
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/search-parser.test.mjs
+++ b/packages/prez-lib/tests/search-parser.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { RDFStore } from "../dist/prez-lib.js";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(currentDir, "fixtures");
+
+function loadFixture(name) {
+    return readFileSync(join(fixturesDir, name), "utf8");
+}
+
+function parseFixture(name, parserMode = "default") {
+    const store = new RDFStore();
+    store.load(loadFixture(name));
+
+    return parserMode === "jena-lucene-shacl"
+        ? store.search({ parserMode })
+        : store.search();
+}
+
+test("parses the default flat search shape", () => {
+    const results = parseFixture("flat-search.ttl");
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].hash, "flat-1");
+    assert.equal(results[0].predicate.value, "https://example.com/title");
+    assert.equal(results[0].match.value, "Flat result match");
+    assert.equal(results[0].resource.value, "https://example.com/item-1");
+});
+
+test("parses a Lucene SHACL result with one nested match", () => {
+    const results = parseFixture("lucene-single-match.ttl", "jena-lucene-shacl");
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].hash, "lucene-1");
+    assert.equal(results[0].matches.length, 1);
+    assert.equal(results[0].matches[0].predicate.value, "https://example.com/comment");
+    assert.equal(results[0].matches[0].match.value, "Single nested snippet");
+});
+
+test("parses a Lucene SHACL result with many nested matches", () => {
+    const results = parseFixture("lucene-multi-match.ttl", "jena-lucene-shacl");
+
+    assert.equal(results.length, 1);
+    assert.deepEqual(
+        results[0].matches.map(match => match.match.value).sort(),
+        ["First nested snippet", "Second nested snippet", "Third nested snippet"]
+    );
+});
+
+test("parses a Lucene SHACL result with zero nested matches", () => {
+    const results = parseFixture("lucene-zero-match.ttl", "jena-lucene-shacl");
+
+    assert.equal(results.length, 1);
+    assert.deepEqual(results[0].matches, []);
+    assert.equal(results[0].resource.value, "https://example.com/item-4");
+});
+
+test("rejects flat legacy search payloads in Lucene SHACL mode", () => {
+    assert.throws(
+        () => parseFixture("flat-search.ttl", "jena-lucene-shacl"),
+        /parserMode is jena-lucene-shacl/
+    );
+});
+
+test("rejects mixed payloads in default mode", () => {
+    assert.throws(
+        () => parseFixture("lucene-mixed-shape.ttl"),
+        /parserMode is default/
+    );
+});
+
+test("rejects mixed payloads in Lucene SHACL mode", () => {
+    assert.throws(
+        () => parseFixture("lucene-mixed-shape.ttl", "jena-lucene-shacl"),
+        /parserMode is jena-lucene-shacl/
+    );
+});


### PR DESCRIPTION
## Summary

This PR adds **opt-in support in `prez-lib` for the Jena Lucene SHACL search result shape** while preserving the existing flat search parser as the default.

The implementation is **strictly mode-based**:

- `default` mode parses the existing flat Prez search shape
- `jena-lucene-shacl` mode parses the nested Jena Lucene SHACL shape
- the configured parser mode must match the backend shape; there is **no mixed-shape fallback**

This is **non-breaking for existing consumers**:

- existing `search(baseUrl, path)` calls continue to use the current flat parser
- consumers only opt into the new behavior when they explicitly pass `parserMode: "jena-lucene-shacl"`

## Why

`prez-lib` previously assumed every `prez:SearchResult` had direct:

- `prez:searchResultPredicate`
- `prez:searchResultMatch`
- `prez:searchResultURI`

That works for the current flat model, but not for Jena Lucene SHACL responses where matches are nested under `prez:hasSearchMatch`.

## Example shapes

### Existing flat shape

```turtle
<urn:hash:flat-1> a prez:SearchResult ;
    prez:searchResultWeight "2.5"^^xsd:float ;
    prez:searchResultPredicate ex:title ;
    prez:searchResultMatch "Flat result match" ;
    prez:searchResultURI ex:item-1 .
```

This still maps to the existing flat result model in `default` mode.

### Jena Lucene SHACL shape

```turtle
<urn:hash:lucene-1> a prez:SearchResult ;
    prez:searchResultWeight "8.222368"^^xsd:float ;
    prez:searchResultURI ex:item-2 ;
    prez:hasSearchMatch <urn:match:1> .

<urn:match:1> a prez:SearchResultMatch ;
    prez:searchResultPredicate ex:comment ;
    prez:searchResultMatch "Single nested snippet" .
```

In `jena-lucene-shacl` mode, this maps to one result with `matches[]`.

### Zero-match Lucene SHACL result

```turtle
<urn:hash:lucene-3> a prez:SearchResult ;
    prez:searchResultWeight "1.75"^^xsd:float ;
    prez:searchResultURI ex:item-4 .
```

This is valid in `jena-lucene-shacl` mode and produces a result with `matches: []`.

## API change

Consumers can now opt into Lucene SHACL parsing by passing `parserMode` to `search()`.

### Default behavior

```ts
const result = await search(baseUrl, "/search?q=gold");
```

This is still the default and is equivalent to:

```ts
const result = await search(baseUrl, "/search?q=gold", {
  parserMode: "default",
});
```

### Lucene SHACL behavior

```ts
const result = await search(baseUrl, "/search?q=gold", {
  parserMode: "jena-lucene-shacl",
});
```

## What changed

### `packages/prez-lib`

- added `PrezSearchParserMode`
- added `PrezSearchOptions`
- added `PrezSearchMatch`
- split flat and Lucene SHACL result types
- added `PREZ_PREDICATES.hasSearchMatch`
- updated `RDFStore.search()` to parse by explicit mode
- updated exported `search()` to accept parser options
- documented the new mode in `README.md`

## Strict parsing behavior

This PR intentionally does **not** support mixed payloads.

If the backend is configured for flat search, use `default`.

If the backend is configured for Jena Lucene SHACL, use `jena-lucene-shacl`.

If those do not match, parsing fails instead of trying to infer intent.

## Tests

Added fixture-backed tests covering:

- flat shape
- nested shape with one match
- nested shape with many matches
- nested shape with zero matches
- flat payload rejected in `jena-lucene-shacl` mode
- mixed payload rejected in both modes