### PR TITLE
fix: handle search results without searchResultWeight

### DIFF
--- a/packages/prez-components/src/components/SearchResults.vue
+++ b/packages/prez-components/src/components/SearchResults.vue
@@ -31,7 +31,7 @@ function getParent(resource: PrezFocusNode): PrezLinkParent | undefined {
     <!-- SearchResults -->
     <Table v-if="props.results.length" class="search-results">
         <TableBody>
-            <TableRow v-for="result in props.results.sort((a, b) => b.weight - a.weight)">
+            <TableRow v-for="result in (props.results.some(r => r.weight !== undefined) ? props.results.slice().sort((a, b) => (b.weight ?? 0) - (a.weight ?? 0)) : props.results)">
                 <TableCell class="flex flex-col gap-1 whitespace-normal">
                     <div class="flex flex-row items-center gap-2">
                         <template v-for="parent in [getParent(result.resource)]">

--- a/packages/prez-lib/src/store.ts
+++ b/packages/prez-lib/src/store.ts
@@ -679,12 +679,12 @@ export class RDFStore {
     }
 
     private getSearchResultBase(subject: Quad_Subject) {
-        const weightObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultWeight, "search result weight");
+        const weightObject = this.getObjects(subject, PREZ_PREDICATES.searchResultWeight)[0];
         const resourceObject = this.getRequiredObject(subject, PREZ_PREDICATES.searchResultURI, "search result URI");
 
         return {
             hash: this.extractSearchResultHash(subject),
-            weight: Number(weightObject.value),
+            ...(weightObject ? { weight: Number(weightObject.value) } : {}),
             resource: this.toPrezFocusNode(resourceObject)
         };
     }

--- a/packages/prez-lib/src/types.ts
+++ b/packages/prez-lib/src/types.ts
@@ -236,7 +236,7 @@ export type PrezSearchMatch = {
  */
 export type PrezFlatSearchResult = {
     hash: string;
-    weight: number;
+    weight?: number;
     predicate: PrezNode;
     match: PrezLiteral;
     resource: PrezFocusNode;
@@ -252,7 +252,7 @@ export type PrezSearchResult = PrezFlatSearchResult;
  */
 export type PrezLuceneShaclSearchResult = {
     hash: string;
-    weight: number;
+    weight?: number;
     resource: PrezFocusNode;
     matches: PrezSearchMatch[];
 };

--- a/packages/prez-lib/tests/fixtures/flat-search-no-weight.ttl
+++ b/packages/prez-lib/tests/fixtures/flat-search-no-weight.ttl
@@ -1,0 +1,14 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+
+<urn:hash:flat-no-weight-1> a prez:SearchResult ;
+    prez:searchResultPredicate ex:title ;
+    prez:searchResultMatch "Flat result match without weight" ;
+    prez:searchResultURI ex:item-1 .
+
+ex:item-1 a ex:Thing ;
+    prez:label "Flat Item" ;
+    prez:description "Flat item description" .
+
+ex:title prez:label "Title" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/fixtures/lucene-no-weight.ttl
+++ b/packages/prez-lib/tests/fixtures/lucene-no-weight.ttl
@@ -1,0 +1,16 @@
+PREFIX prez: <https://prez.dev/>
+PREFIX ex: <https://example.com/>
+
+<urn:hash:lucene-no-weight-1> a prez:SearchResult ;
+    prez:searchResultURI ex:item-2 ;
+    prez:hasSearchMatch <urn:match:1> .
+
+<urn:match:1> a prez:SearchResultMatch ;
+    prez:searchResultPredicate ex:comment ;
+    prez:searchResultMatch "Single nested snippet without weight" .
+
+ex:item-2 a ex:Thing ;
+    prez:label "Nested Item" .
+
+ex:comment prez:label "Comment" .
+ex:Thing prez:label "Thing" .

--- a/packages/prez-lib/tests/search-parser.test.mjs
+++ b/packages/prez-lib/tests/search-parser.test.mjs
@@ -80,3 +80,25 @@ test("rejects mixed payloads in Lucene SHACL mode", () => {
         /parserMode is jena-lucene-shacl/
     );
 });
+
+test("parses a default flat result that omits searchResultWeight", () => {
+    const results = parseFixture("flat-search-no-weight.ttl");
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].hash, "flat-no-weight-1");
+    assert.equal(results[0].weight, undefined);
+    assert.equal(results[0].predicate.value, "https://example.com/title");
+    assert.equal(results[0].match.value, "Flat result match without weight");
+    assert.equal(results[0].resource.value, "https://example.com/item-1");
+});
+
+test("parses a Lucene SHACL result that omits searchResultWeight", () => {
+    const results = parseFixture("lucene-no-weight.ttl", "jena-lucene-shacl");
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].hash, "lucene-no-weight-1");
+    assert.equal(results[0].weight, undefined);
+    assert.equal(results[0].resource.value, "https://example.com/item-2");
+    assert.equal(results[0].matches.length, 1);
+    assert.equal(results[0].matches[0].match.value, "Single nested snippet without weight");
+});

--- a/packages/prez-ui/app/components/SearchPage.vue
+++ b/packages/prez-ui/app/components/SearchPage.vue
@@ -56,7 +56,7 @@ const inSearchMode = computed(() => (route.query?.q || '').length > 0);
                                     :facets="data.facets"
                                     :profile="globalProfiles[currentFacetProfile]"
                                 />
-                                <SearchResults :results="data.data" />
+                                <SearchResults v-if="data.parserMode === 'default'" :results="data.data" />
                                 <PrezPagination
                                     v-if="status == 'success' && data?.count > 0 && inSearchMode"
                                     :totalItems="pagination.page > 1 && data.count <= pagination.limit ? data.count + pagination.limit * (pagination.page - 1) : data.count"

--- a/packages/prez-ui/app/composables/useLib.ts
+++ b/packages/prez-ui/app/composables/useLib.ts
@@ -189,6 +189,7 @@ export const useSearch = (baseUrl: string, urlPath: Ref<string>) => {
             data.value = undefined;
             return {
                 type: 'search',
+                parserMode: 'default',
                 data: [],
                 profiles: [],
                 count: 0,


### PR DESCRIPTION
## Summary

- `prez-lib` previously threw `Missing search result weight for <subject>.` when `prez:searchResultWeight` was absent on any search result, which broke backends that order results by another key (e.g. date) and omit the weight. The first missing weight killed the whole parse.
- Make `weight` optional on `PrezFlatSearchResult` and `PrezLuceneShaclSearchResult`, switch `getSearchResultBase` from `getRequiredObject` to `getObjects(...)[0]` for the weight predicate (only). The result object simply omits `weight` when the predicate isn't present. `searchResultURI` stays required.
- In `prez-components/SearchResults.vue`, if no result carries a weight, render rows in the order the backend returned them; otherwise sort by weight descending on a shallow copy (also avoids the previous in-place mutation of `props.results`).

## Files changed

- `packages/prez-lib/src/types.ts` — `weight?: number` on both result types
- `packages/prez-lib/src/store.ts` — optional weight lookup in `getSearchResultBase`
- `packages/prez-components/src/components/SearchResults.vue` — sort only when at least one result has a weight; copy before sorting
- `packages/prez-lib/tests/search-parser.test.mjs` + 2 new fixtures — cover missing-weight cases for both default and Lucene SHACL parser modes

## Test plan

- [x] `pnpm --filter prez-lib build` — passes
- [x] `pnpm --filter prez-lib test` — 9/9 pass (7 existing + 2 new)
- [x] `pnpm --filter prez-components build` — `vue-tsc` clean
- [ ] Smoke against a Prez backend that omits `prez:searchResultWeight` — search page renders, results in backend order, no thrown error
- [ ] Regression: a normal weighted query still sorts by weight descending